### PR TITLE
fixed maxListeners '0' value handling

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -138,7 +138,7 @@
 
     // If the max amount of listeners has been reached signal and return to
     // cancel the addition of this new listener.
-    if (eventListeners.length >= maxListeners) {
+    if (maxListeners > 0 && eventListeners.length >= maxListeners) {
       self.emit('maxListeners', event);
       return self;
     }

--- a/test/basicEvents.js
+++ b/test/basicEvents.js
@@ -875,4 +875,34 @@ module.exports = basicEvents({
     test.expect(2);
     test.done();
   },
+  '34. should able to permit unlimited listeners for the maxListeners values less equal then \'0\'' : function (test) {
+
+    if(typeof require !== 'undefined') {
+      EventEmitter2 = require('../lib/eventemitter2').EventEmitter2;
+    }
+    else {
+      EventEmitter2 = window.EventEmitter2;
+    }
+    try {
+      var emitter = new EventEmitter2({ 
+        maxListeners : 0
+      });
+      emitter.on('test34', function () {
+        test.ok(true, 'listener was raised');
+      });
+    }
+    catch (ex) {
+      test.ok(false, 'Error was raised');
+    }
+    
+    // some value greater that the default one
+    var listenerCount = 11
+    
+    for (var i = 0; i < listenerCount ; i++){
+      emitter.emit('test34');
+    }
+    
+    test.expect(listenerCount);
+    test.done();
+  }
 });


### PR DESCRIPTION
Setting maxListeners less equal to the value '0' do not permit the unlimited listener addition.

Also added a test (34), though i could not able to be sure that the test (32) was handling this issue.
