### PR TITLE
[test v0.6] Add typed arrays to known globals

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -64,6 +64,17 @@ process.on('exit', function() {
                       console,
                       Buffer,
                       process,
+                      ArrayBuffer,
+                      Int8Array,
+                      Uint8Array,
+                      Int16Array,
+                      Uint16Array,
+                      Int32Array,
+                      Uint32Array,
+                      Float32Array,
+                      Float64Array,
+                      DataView,
+                      AssertionError,
                       global];
 
   if (global.errno) {


### PR DESCRIPTION
As seen here: https://developer.mozilla.org/en/JavaScript_typed_arrays,
many new data types were added, thus resulting in new variables in
global namespace. This caused tests to fail. I added them to
`knownGlobals` in orded to be properly recognized as valid global
variables.

I added `AssertionError` as well, because it seems that _something_
leaks it.  However, I'm sure that it's not our code:

```
maciej@pc07 EventEmitter2 (0.6-compatibility)]$ ls
README.md   index.js    lib     node_modules    package.json    test
[maciej@pc07 EventEmitter2 (0.6-compatibility)]$ node
> require('./')
{ EventEmitter2: [Function: EventEmitter] }
> AssertionError
ReferenceError: AssertionError is not defined
    at repl:1:2
    at REPLServer.eval (repl.js:76:28)
    at Interface.<anonymous> (repl.js:175:12)
    at Interface.emit (events.js:67:17)
    at Interface._onLine (readline.js:162:10)
    at Interface._line (readline.js:426:8)
    at Interface._ttyWrite (readline.js:603:14)
    at ReadStream.<anonymous> (readline.js:82:12)
    at ReadStream.emit (events.js:88:20)
    at ReadStream._emitKey (tty_uv.js:309:10)
```

It may be caused by nodeunit.

Tests pass on node v0.5.9 now.
