### PR TITLE
Make '**' accept none or several elements

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -30,10 +30,9 @@
     if (!tree) {
       return;
     }
-
-    var listeners, leaf, len, branch, xTree, xxTree, isolatedBranch,
-        matchingBranches = [], pendingBranches = [], nextType = type[i+1];
-    if (i === type.length && tree._listeners) {
+    var listeners, leaf, len, branch, xTree, xxTree, isolatedBranch, endReached,
+        typeLength = type.length, currentType = type[i], nextType = type[i+1];
+    if (i === typeLength && tree._listeners) {
       //
       // If at the end of the event(s) list and the tree has listeners
       // invoke those listeners.
@@ -49,37 +48,44 @@
       }
     }
 
-    if ((type[i] === '*' || type[i] === '**') || tree[type[i]]) {
+    if ((currentType === '*' || currentType === '**') || tree[currentType]) {
       //
       // If the event emitted is '*' at this part
       // or there is a concrete match at this patch
       //
-      if (type[i] === '*') {
+      if (currentType === '*') {
         for (branch in tree) {
           if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
             listeners = searchListenerTree(handlers, type, tree[branch], i+1);
           }
         }
         return listeners;
-      } else if(type[i] === '**') {
+      } else if(currentType === '**') {
+        endReached = (i+1 === typeLength || (i+2 === typeLength && nextType === '*'));
+        if(endReached && tree._listeners) {
+          // The next element has a _listeners, add it to the handlers.
+          listeners = searchListenerTree(handlers, type, tree, typeLength);
+        }
+
         for (branch in tree) {
           if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
-            if(branch === nextType || branch === '*' || branch === '**' || nextType === '*') {
-              // The next element matches, move forware in the tree.
-              listeners = searchListenerTree(handlers, type, tree[branch], i+1);
-            } else if(tree[branch]._listeners) {
-              // The next element has a _listeners, add it to the handlers.
-              listeners = searchListenerTree(handlers, type, tree[branch], type.length);
+            if(branch === '*' || branch === '**') {
+              if(tree[branch]._listeners && !endReached) {
+                listeners = searchListenerTree(handlers, type, tree[branch], typeLength);
+              }
+              listeners = searchListenerTree(handlers, type, tree[branch], i);
+            } else if(branch === nextType) {
+              listeners = searchListenerTree(handlers, type, tree[branch], i+2);
             } else {
               // No match on this one, shift into the tree but not in the type array.
-              searchListenerTree(handlers, type, tree[branch], i);
+              listeners = searchListenerTree(handlers, type, tree[branch], i);
             }
           }
         }
         return listeners;
       }
 
-      listeners = searchListenerTree(handlers, type, tree[type[i]], i+1);
+      listeners = searchListenerTree(handlers, type, tree[currentType], i+1);
     }
 
     xTree = tree['*'];
@@ -93,41 +99,33 @@
     
     xxTree = tree['**'];
     if(xxTree) {
-      if(i < type.length) {
+      if(i < typeLength) {
+        if(xxTree._listeners) {
+          // If we have a listener on a '**', it will catch all, so add its handler.
+          searchListenerTree(handlers, type, xxTree, typeLength);
+        }
+        
         // Build arrays of matching next branches and others.
-        for(var branch in xxTree) {
+        for(branch in xxTree) {
           if(branch !== '_listeners' && xxTree.hasOwnProperty(branch)) {
-            if(branch === '*' || branch === nextType) {
-              matchingBranches.push(branch);
+            if(branch === nextType) {
+              // We know the next element will match, so jump twice.
+              searchListenerTree(handlers, type, xxTree[branch], i+2);
+            } else if(branch === currentType) {
+              // Current node matches, move into the tree.
+              searchListenerTree(handlers, type, xxTree[branch], i+1);
             } else {
-              pendingBranches.push(branch);
+              isolatedBranch = {};
+              isolatedBranch[branch] = xxTree[branch];
+              searchListenerTree(handlers, type, { '**': isolatedBranch }, i+1);
             }
           }
         }
-        
-        var finalLoop = (i+1 === type.length);
-        
-        if(matchingBranches.length) {
-          if(xxTree._listeners) {
-            // If we have a listener on a '**', it will catch all, so add its handler.
-            searchListenerTree(handlers, type, xxTree, type.length);
-          }
-          while(leaf = matchingBranches.shift()) {
-            // We know the next element will match, so jump twice.
-            searchListenerTree(handlers, type, xxTree[leaf], i+2);
-          }
-        } else {
-          // Keep shifting into the type, take care to isolate the '**' branch
-          // to avoid parsing other branches at the same level again.
-          searchListenerTree(handlers, type, finalLoop ? xxTree : { '**': xxTree }, i+1);
-        }
-        
-        // Process the remaining branches and isolate their branch.
-        while(leaf = pendingBranches.shift()) {
-          isolatedBranch = {};
-          isolatedBranch[leaf] = xxTree[leaf];
-          searchListenerTree(handlers, type, finalLoop ? isolatedBranch : { '**': isolatedBranch }, i+1);
-        }
+      } else if(xxTree._listeners) {
+        // We have reached the end and still on a '**'
+        searchListenerTree(handlers, type, xxTree, typeLength);
+      } else if(xxTree['*'] && xxTree['*']._listeners) {
+        searchListenerTree(handlers, type, xxTree['*'], typeLength);
       }
     }
 
@@ -222,7 +220,7 @@
       if (--ttl === 0) {
         self.off(event, listener);
       }
-      fn.apply(null, arguments);
+      fn.apply(this, arguments);
     };
 
     listener._origin = fn;

--- a/test/wildcardEvents/addListener.js
+++ b/test/wildcardEvents/addListener.js
@@ -245,35 +245,43 @@ module.exports = simpleEvents({
     test.done();
   },
   
-  '11. Listeners on `**`, `*.**`, `**.*`, `**.**`, `**.test`, `**.bar.**`, `other.**` with emissions from `foo.bar.test` and `other.emit`': function (test) {
+  '11. Listeners with multi-level wildcards': function (test) {
     var emitter = this.emitter;
     var i = 0;
     var f = function (n) {
       return function() {
-        //console.log('Event', n, 'fired');
+        //console.log('Event', n, 'fired by', this.event);
         test.ok(true, 'the event was fired');
       };
     };
 
-    emitter.on('**.test', f(i++));     // 0: 0 + 1 + 0 + 0 + 1
-    emitter.on('**.bar.**', f(i++));   // 1: 0 + 1 + 1 + 1 + 0
-    emitter.on('**.*', f(i++));        // 2: 1 + 0 + 0 + 0 + 1
-    emitter.on('*.**', f(i++));        // 3: 1 + 1 + 1 + 1 + 1
-    emitter.on('**', f(i++));          // 4: 1 + 1 + 1 + 1 + 0
-    emitter.on('other.**', f(i++));    // 5: 1 + 0 + 0 + 0 + 1
-    emitter.on('foo.**.test', f(i++)); // 6: 0 + 1 + 0 + 0 + 0
+    emitter.on('**.test', f(i++));     // 0: 0 + 1 + 0 + 0 + 1 + 1 + 1 + 1 + 1 + 1
+    emitter.on('**.bar.**', f(i++));   // 1: 0 + 1 + 1 + 1 + 1 + 0 + 0 + 1 + 1 + 1
+    emitter.on('**.*', f(i++));        // 2: 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
+    emitter.on('*.**', f(i++));        // 3: 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
+    emitter.on('**', f(i++));          // 4: 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1
+    emitter.on('other.**', f(i++));    // 5: 1 + 0 + 0 + 0 + 1 + 0 + 0 + 0 + 1 + 1
+    emitter.on('foo.**.test', f(i++)); // 6: 0 + 1 + 0 + 0 + 1 + 0 + 1 + 1 + 1 + 1
+    emitter.on('test.**', f(i++));     // 7: 0 + 0 + 0 + 0 + 1 + 1 + 0 + 0 + 1 + 1
     // Add forbidden patterns for safety purpose.
-    emitter.on('**.**', f(i++));         // 7: 0
-    emitter.on('a.b.**.**', f(i++));     // 8: 0
-    emitter.on('**.**.a.b', f(i++));     // 9: 0
-    emitter.on('a.b.**.**.a.b', f(i++)); // 10: 0
+    emitter.on('**.**', f(i++));
+    emitter.on('a.b.**.**', f(i++));
+    emitter.on('**.**.a.b', f(i++));
+    emitter.on('a.b.**.**.a.b', f(i++));
 
     emitter.emit('other.emit');   // 4  
-    emitter.emit('foo.bar.test'); // 5
-    emitter.emit('foo.bar.test.bar.foo.test.foo'); // 3
-    emitter.emit('bar.bar.bar.bar.bar.bar'); // 3
-    emitter.emit('**.*'); // 4
+    emitter.emit('foo.bar.test'); // 6
+    emitter.emit('foo.bar.test.bar.foo.test.foo'); // 4
+    emitter.emit('bar.bar.bar.bar.bar.bar'); // 4
+    emitter.emit('**.*'); // 8
+    emitter.emit('test'); // 5
+    emitter.emit('foo.test'); // 5
+    emitter.emit('foo.**.*'); // 6
+    emitter.emit('**.test'); // 8
+    emitter.emit('**.test.**'); // 8
+    //emitter.emit('*.**.test.**.a'); // 0
     
-    test.expect(19);
-  
+    test.expect(58);
+    test.done();
+  }
 });

--- a/test/wildcardEvents/customDelimiter.js
+++ b/test/wildcardEvents/customDelimiter.js
@@ -193,20 +193,23 @@ module.exports = simpleEvents({
   },
   
   '10. Listeners on **, **::*, foo.test with emissions from **, **::* and foo.test': function (test) {
-    var emitter = this.emitter;
-    var f = function () {
-      test.ok(true, 'the event was fired');
+    var emitter = this.emitter, i = 0;
+    var f = function (n) {
+      return function() {
+        //console.log(n, this.event);
+        test.ok(true, 'the event was fired');
+      };
     };
 
-    emitter.on('foo::test', f);
-    emitter.on('**::*', f);
-    emitter.on('**', f);
+    emitter.on('foo::test', f(i++));
+    emitter.on('**::*', f(i++));
+    emitter.on('**', f(i++));
 
-    emitter.emit('**::*'); // 2   
-    emitter.emit('foo::test'); // 2
+    emitter.emit('**::*'); // 3   
+    emitter.emit('foo::test'); // 3
     emitter.emit('**'); // 3
     
-    test.expect(7);
+    test.expect(9);
     test.done();
   }
 

--- a/test/wildcardEvents/ttl.js
+++ b/test/wildcardEvents/ttl.js
@@ -161,13 +161,17 @@ module.exports = simpleEvents({
   },
   
   '8. Emitting with a multi-level wildcard on once': function(test) {
-    var emitter = this.emitter;
+    var emitter = this.emitter, i = 0;
     var type = 'test1.**';
-    var functionA = function() { test.ok(true, 'Event was fired'); };
+    var functionA = function(n) {
+      return function() {
+        //console.log(n, this.event);
+        test.ok(true, 'Event was fired');
+      };
+    }
 
-    emitter.once(type, functionA);
-    emitter.on(type,functionA);
-
+    emitter.once(type, functionA(i++));
+    emitter.on(type,functionA(i++));
     emitter.emit(type); //2
     emitter.emit(type); //1
 


### PR DESCRIPTION
Hello again @hij1nx,

Here is the promised patch for the '**' feature to eat all or nothing.
Multi-level wildcards have been a real pain to deal with in the emit message, I got all the tests covered but there may be edge cases that are not. Hope it's still enough for people to begin using it.
Let me know if the code is not good enough.

 /cc @Marak
