### PR TITLE
Add default delimiter to the prototype so it can be discovered reliably via emitter.delimiter

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -10,11 +10,9 @@
   }
 
   function configure(conf) {
-
     if (conf) {
-      this.wildcard = conf.wildcard;
-      this.delimiter = conf.delimiter || '.';
-
+      conf.delimiter && (this.delimiter = conf.delimiter);
+      conf.wildcard && (this.wildcard = conf.wildcard);
       if (this.wildcard) {
         this.listenerTree = new Object;
       }
@@ -196,6 +194,8 @@
   //
   // Obviously not all Emitters should be limited to 10. This function allows
   // that to be increased. Set to zero for unlimited.
+
+  EventEmitter.prototype.delimiter = '.';
 
   EventEmitter.prototype.setMaxListeners = function(n) {
     this._events || init.call(this);


### PR DESCRIPTION
Code that is passed an EventEmitter2 should not need to be paramterized over the delimiter that should be used.  Neither should it need to assume that the default delimiter is always '.' and use this if the delimiter is not set.  This is a quick, non-breaking fix that adds the default '.' delimiter to the prototype so that the delimiter (default or otherwise) can always be discovered with `emitter.delimiter`.
