### PR TITLE
[api] Check for existence of `process.title`

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -544,4 +544,4 @@
     exports.EventEmitter2 = EventEmitter; 
   }
 
-}(typeof process !== 'undefined' && process.title ? exports : window);
+}(typeof process !== 'undefined' && typeof process.title !== 'undefined' ? exports : window);


### PR DESCRIPTION
Checking for truthness fails on Solaris, which doesn't support process
titles (`process.title === ''`).
