### PR TITLE
Check for 'exports' existence

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -544,4 +544,4 @@
     exports.EventEmitter2 = EventEmitter; 
   }
 
-}(typeof process !== 'undefined' && typeof process.title !== 'undefined' ? exports : window);
+}(typeof process !== 'undefined' && typeof process.title !== 'undefined' && typeof exports !== 'undefined' ? exports : window);


### PR DESCRIPTION
exports needs to be defined in order for the expression to work. If
process/process.title ends up being defined in an outer context, chrome throws
an error because exports is not defined.

This fixes the immediate error, but I think it would be preferable to switch the way this code is being wrapped, and expand the exporting code to operate like underscore.js for maximum compatibility.

``` javascript
(function() {
  var root = this;
  /* ..... */

  if (typeof exports !== 'undefined') {
    if (typeof module !== 'undefined' && module.exports) {
      exports = module.exports = EventEmitter;
    }
    exports.EventEmitter2 = EventEmitter;
  } else {
    // Exported as a string, for Closure Compiler "advanced" mode.
    root['EventEmitter2'] = EventEmitter;
  }

}).call(this);
```

Thoughts on the deeper change?
