### PR TITLE
emit should return false when event not handled

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -318,7 +318,7 @@
         this.event = type;
         listeners[i].apply(this, args);
       }
-      return true;
+      return listeners.length > 0;
     }
     else {
       return false;


### PR DESCRIPTION
var EventEmitter = require('eventemitter2').EventEmitter2;
var assert = require('assert');
var ee = new EventEmitter({wildcard: true});

ee.on("foo", function() {
    console.log("handled");
});

assert.ok(!ee.emit("bar"), "emit should return false when event not handled");
console.log("passed");
