### PR TITLE
add idle() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ Returns an array of listeners that are listening for any event that is specified
 
 Execute each of the listeners that may be listening for the specified event name in order with the list of arguments.
 
+#### emitter.idle(event, timeout, callback, [arg1], [arg2], [...])
+
+Sets an idle timer that calls the specified callback with the event and arguments if the event is not emitted within the specified timeout.  Upon the event being emitted, the timer is set back up.
+
 ## Test coverage
 
 There is a test suite that tries to cover each use case, it can be found <a href="https://github.com/hij1nx/EventEmitter2/tree/master/test">here</a>.

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -544,4 +544,37 @@
     exports.EventEmitter2 = EventEmitter; 
   }
 
+  EventEmitter.prototype.idle = function() {
+    var args = Array.prototype.slice.call(arguments, 0);
+    var event = args.shift();
+    var timeout = args.shift();
+    var fn = args.shift();
+    
+    var self = this;
+
+    var callback = function () {
+      console.log("in callback");
+      self.removeListener(event, self.idle);
+console.log("listener removed");
+      var newargs = args.slice(0);
+      newargs.unshift(event);
+
+      fn.apply(self, newargs);
+    };
+
+    var timerId = setTimeout(callback, timeout);
+
+    // remove the timeout and reset the idle timer in case of event
+    self.once(event, function () {
+      console.log("in once");
+      clearTimeout(timerId);
+
+      args.unshift(fn);
+      args.unshift(timeout);
+      args.unshift(event);
+
+      self.idle.apply(self, args);
+    });
+  };
+
 }(typeof process !== 'undefined' && typeof process.title !== 'undefined' && typeof exports !== 'undefined' ? exports : window);

--- a/test/simple/idle.js
+++ b/test/simple/idle.js
@@ -1,0 +1,75 @@
+var simpleEvents = require('nodeunit').testCase;
+
+var file = '../../lib/eventemitter2';
+
+module.exports = simpleEvents({
+
+  setUp: function (callback) {
+    var EventEmitter2;
+
+    if(typeof require !== 'undefined') {
+      EventEmitter2 = require(file).EventEmitter2;
+    }
+    else {
+      EventEmitter2 = window.EventEmitter2;
+    }
+
+    this.emitter = new EventEmitter2({ verbose: true });
+    callback();
+  },
+
+  tearDown: function (callback) {
+    //clean up?
+    callback();
+  },
+
+  '1. Add an idletimer and do not emit the event.': function (test) {
+
+    var emitter = this.emitter;
+
+    function callback() {
+      test.ok(true, 'The event was raised');
+      test.expect(1);
+      test.done();
+    }
+
+    emitter.idle('test', 1, callback);
+  },
+
+  '2. Add an idletimer and emit the event.': function (test) {
+
+    var emitter = this.emitter;
+
+    function callback() {
+      test.ok(true, 'Then the idle event was raised');
+      test.expect(2);
+      test.done();
+    }
+
+    emitter.idle('test', 1, callback);
+    emitter.on('test', function () {
+      test.ok(true, 'The correct event was raised');
+    });
+
+    emitter.emit('test');
+  },
+
+  '3. Add an idletimer and pass arguments.': function (test) {
+
+    var emitter = this.emitter;
+
+    function callback(event, arg1, arg2) {
+      test.ok(true, 'Then the idle event was raised');
+      test.equal(arg1, 'some', 'The first argument is correct');
+      test.equal(arg2, 'arguments', 'The second argument is correct');
+      test.expect(3);
+      test.done();
+    }
+
+    emitter.idle('test', 1, callback, 'some', 'arguments');
+
+    emitter.emit('test');
+  },
+
+});
+


### PR DESCRIPTION
adds idle() method to ee2 - sets a timer, if an event has not been fired by the time the timer runs out then the callback is fired with the event and the arguments:

```
emitter.idle(event, timeout, callback, [arg1], [arg2], [...])
```

each time the event is emitted, the idle timer is reset.  if the idle timeout occurs and the callback is fired, the idle timeout is canceled (no further timeouts until idle() is reset).

```
emitter.idle('hello', 100, function (event, arg1, arg2) {
  console.log(event); // 'hello'
  console.log(arg1); // 'foo'
  console.log(arg2); // 'bar'
}, 'foo', 'bar');
```
