### PR TITLE
Potential fix for #47

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -245,10 +245,6 @@
 
     var type = arguments[0];
 
-    if (type === 'newListener') {
-      if (!this._events.newListener) { return false; }
-    }
-
     // Loop through the *_all* functions and invoke them.
     if (this._all) {
       var l = arguments.length;


### PR DESCRIPTION
This change allows the newListener event to fire when the wildcard option is true:

https://github.com/hij1nx/EventEmitter2/issues/47

Don't know if there are other ramifications here, but the deleted block seems like it would have messed with the _all handlers firing as well, unless that's on purpose.

::ja
