### PR TITLE
Use singular repository to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   ],
   "licenses": [{"type": "MIT"}],
   "homepage": "https://github.com/hij1nx/EventEmitter2",
-  "repositories": [{
+  "repository": {
       "type": "git",
       "url": "git://github.com/hij1nx/EventEmitter2.git" 
-  }],
+  },
   "devDependencies": {
     "nodeunit": "*",
     "benchmark" : ">= 0.2.2"


### PR DESCRIPTION
Hi! It appears having the plural `repositories` in your package.json will give a warning:

```
npm WARN package.json eventemitter2@0.4.11 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

This updates to use the singular `repository`. Reference isaacs/npm#2624 and gruntjs/grunt-lib-contrib#8

Thanks!
