### PR TITLE
Fix to benchmark.js to show cycle stats instead of undefined

### DIFF
--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -44,10 +44,10 @@ suite
   })
 
   .on('cycle', function(event, bench) {
-    console.log(String(bench));
+    console.log(String(event.target));
   })
   .on('complete', function() {
-    console.log('Fastest is ' + this.filter('fastest').pluck('name'));
+    console.log('\nFastest is ' + this.filter('fastest').pluck('name'));
   })
 
   .run(true);


### PR DESCRIPTION
`String(bench)` seems not to work anymore, Replaced with `String(event.target)` as in the sample in [benchmarkjs.com](http://benchmarkjs.com)

Regards!
