### PR TITLE
constructor: do not initialize this._events - leave this for .init()

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -29,7 +29,6 @@
   }
 
   function EventEmitter(conf) {
-    this._events = {};
     this.newListener = false;
     configure.call(this, conf);
   }


### PR DESCRIPTION
Not only this is saner since on every method call there is a check "this._events || init.call(this);", but this patch also enables using EventEmitter2 as a prototype - someone might need to make a "subclass" - extend EventEmitter2
