### PR TITLE
Add benchmarks using * and **

### DIFF
--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -7,6 +7,8 @@ var emitter = new EventEmitter;
 
 var EventEmitter2 = require('../../lib/eventemitter2').EventEmitter2;
 var emitter2 = new EventEmitter2;
+var emitter4 = new EventEmitter2({ wildcard: true });
+var emitter5 = new EventEmitter2({ wildcard: true });
 
 var EventEmitter3 = require('events').EventEmitter;
 var emitter3 = new EventEmitter3;
@@ -40,6 +42,22 @@ suite
     emitter2.on('test2.foo', function () { 1==1; });
     emitter2.emit('test2.foo');
     emitter2.removeAllListeners('test2.foo');
+
+  })
+
+  .add('EventEmitter2 (single-level wildcard)', function() {
+
+    emitter4.on('test4.*', function () { 1==1; });
+    emitter4.emit('test4.foo');
+    emitter4.removeAllListeners('test4.*');
+
+  })
+
+  .add('EventEmitter2 (multi-level wildcard)', function() {
+
+    emitter5.on('start.**.end', function () { 1==1; });
+    emitter5.emit('start.foo.bar.end');
+    emitter5.removeAllListeners('start.**.end');
 
   })
 


### PR DESCRIPTION
Benchmark results:

EventEmitterHeatUp x 9,677,767 ops/sec ±0.54% (100 runs sampled)
EventEmitter x 4,637,885 ops/sec ±0.32% (99 runs sampled)
EventEmitter2 x 8,132,665 ops/sec ±0.40% (96 runs sampled)
EventEmitter2 (wild) x 4,538,810 ops/sec ±7.98% (93 runs sampled)
EventEmitter2 (single-level wildcard) x 251,624 ops/sec ±0.41% (102 runs sampled)
EventEmitter2 (multi-level wildcard) x 187,027 ops/sec ±0.60% (99 runs sampled)

Fastest is EventEmitterHeatUp

Wildcard results as expected but why is EventEmitterHeatUp so quick? I get that every time.
