### PR TITLE
Explicitly define contents of npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
   "scripts" : {
     "test" : "nodeunit test/simple/* && nodeunit test/wildcardEvents/*",
     "benchmark" : "node test/perf/benchmark.js"
-  }
+  },
+  "files": [
+    "lib/eventemitter2.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Every byte counts for popular packages like this one, and the `test` folder is 100kb.
