### PR TITLE
Add support for componentjs

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,17 @@
+{
+  "name": "EventEmitter2",
+  "version": "0.4.13",
+  "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL and browser support.",
+  "keywords": [
+    "event",
+    "events",
+    "emitter",
+    "eventemitter"
+  ],
+  "main": "lib/eventemitter2.js",
+  "scripts": [
+    "lib/eventemitter2.js"
+  ],
+  "license": "MIT",
+  "repo": "https://raw.github.com/littlebitselectronics/EventEmitter2"
+}

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -558,4 +558,4 @@
     exports.EventEmitter2 = EventEmitter;
   }
 
-}(typeof process !== 'undefined' && typeof process.title !== 'undefined' && typeof exports !== 'undefined' ? exports : window);
+}(module && exports && module.exports === exports ? exports : window);


### PR DESCRIPTION
I've had to modify the way EE2 checks for `exports`. It may no longer be assumed that the commonjs module system is tied to `node` (thus no checking for `process`).

Componentjs:
https://github.com/component/component
http://component.io/
