### PR TITLE
Sync component require with node require

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
-  "name": "EventEmitter2",
+  "name": "eventemitter2",
   "version": "0.4.13",
   "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL and browser support.",
   "keywords": [


### PR DESCRIPTION
The current setup causes `component` to expect `require('EventEmitter2')` while `npm` expects `require('eventemitter2')`.
