### PR TITLE
Ensure .emit() returns a Boolean

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -338,10 +338,10 @@
         this.event = type;
         listeners[i].apply(this, args);
       }
-      return (listeners.length > 0) || this._all;
+      return (listeners.length > 0) || !!this._all;
     }
     else {
-      return this._all;
+      return !!this._all;
     }
 
   };


### PR DESCRIPTION
In some return points, `.emit()` is returning a truthy a value, but not a true Boolean as the Node EventEmitter API prescribes.
