### PR TITLE
Fixed memory leak

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -486,6 +486,26 @@
       }
     }
 
+    function recursivelyGarbageCollect(root) {
+      if (root === undefined) {
+        return;
+      }
+      var keys = Object.keys(root);
+      for (var i in keys) {
+        var key = keys[i];
+        var obj = root[key];
+        if (obj instanceof Function)
+          continue;
+        if (Object.keys(obj).length > 0) {
+          recursivelyGarbageCollect(root[key]);
+        }
+        if (Object.keys(obj).length === 0) {
+          delete root[key];
+        }
+      }
+    }
+    recursivelyGarbageCollect(this.listenerTree);
+
     return this;
   };
 


### PR DESCRIPTION
Keys where left with empty objects instead of being entirely cleaned up,
when wildcards are enabled. The examples in #65 results in a garbage
collected tree with this patch.

Fixes #65
