### PR TITLE
Prevent _events creation on emit()

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -298,6 +298,9 @@
   };
 
   EventEmitter.prototype.emit = function() {
+    if (!this._events && !this._all) {
+      return false;
+    }
 
     this._events || init.call(this);
 
@@ -404,6 +407,9 @@
   };
 
   EventEmitter.prototype.emitAsync = function() {
+    if (!this._events && !this._all) {
+      return false;
+    }
 
     this._events || init.call(this);
 


### PR DESCRIPTION
If an emitter doesn't listen to any events, it shouldn't set up structures for them when `emit()` / `emitAsync()` is called.

This simple optimisation improves performance in my use-case quite a lot. I have a lot of objects that rarely have events listeners installed on them, but they do emit events internally in many places for those who do. This simple addition optimizes for the most common case where they have nothing installed, without breaking any tests.

It even seems to have an impact on the benchmark test:

Before:

```
 npm run benchmark

> eventemitter2@5.0.1 benchmark /Users/lehni/Development/Lineto/EventEmitter2
> node test/perf/benchmark.js

EventEmitterHeatUp x 4,592,188 ops/sec ±0.69% (93 runs sampled)
EventEmitter x 4,502,165 ops/sec ±0.87% (93 runs sampled)
EventEmitter2 x 13,786,812 ops/sec ±1.02% (89 runs sampled)
EventEmitter2 (wild) x 9,030,553 ops/sec ±0.64% (92 runs sampled)

Fastest is EventEmitter2
```

After:

```
npm run benchmark

> eventemitter2@5.0.1 benchmark /Users/lehni/Development/Lineto/EventEmitter2
> node test/perf/benchmark.js

EventEmitterHeatUp x 4,571,509 ops/sec ±0.80% (91 runs sampled)
EventEmitter x 4,502,932 ops/sec ±0.90% (93 runs sampled)
EventEmitter2 x 14,033,599 ops/sec ±1.05% (90 runs sampled)
EventEmitter2 (wild) x 9,420,679 ops/sec ±0.62% (92 runs sampled)

Fastest is EventEmitter2
```