### PR TITLE
Feature events.once() & reworked emitter.WaitFor()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ npm-debug.log
 .idea
 .nyc_output
 coverage
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ emitter.emitAsync('get',0)
 ```
 
 ### emitter.waitFor(event, [options])
+### emitter.waitFor(event, [timeout])
+### emitter.waitFor(event, [filter])
 
 Returns a thenable object (promise interface) that resolves when a specific event occurs
 
@@ -366,7 +368,9 @@ emitter.waitFor('event', {
     //filter function to determine acceptable values for resolving the promise.
     filter: function(arg0, arg1){ 
         return arg0==='foo' && arg1==='bar'
-    }   
+    },
+    Promise: Promise, // Promise constructor to use,
+    overload: false // overload cancellation api in a case of external Promise class
 }).then(function(data){
     console.log(data); // ['foo', 'bar']
 });
@@ -406,6 +410,12 @@ console.log(emitter.eventNames());
 ```
 
 ### EventEmitter2.once(emitter, name, [options])
+Creates a cancellable Promise that is fulfilled when the EventEmitter emits the given event or that is rejected
+when the EventEmitter emits 'error'. 
+The Promise will resolve with an array of all the arguments emitted to the given event.
+This method is intentionally generic and works with the web platform EventTarget interface,
+which has no special 'error' event semantics and does not listen to the 'error' event.
+
 Basic example:
 ````javascript
 var emitter= new EventEmitter2();

--- a/README.md
+++ b/README.md
@@ -404,3 +404,73 @@ emitter.on('bar', () => {});
 console.log(emitter.eventNames());
 // Prints: [ 'foo', 'bar' ]
 ```
+
+### EventEmitter2.once(emitter, name, [options])
+Basic example:
+````javascript
+var emitter= new EventEmitter2();
+
+EventEmitter2.once(emitter, 'event', {
+    timeout: 0,
+    Promise: Promise, // a custom Promise constructor
+    overload: false // overload promise cancellation api if exists with library implementation
+}).then(function(data){
+    console.log(data); // [1, 2, 3]
+});
+
+emitter.emit('event', 1, 2, 3);
+````
+With timeout option:
+````javascript
+EventEmitter2.once(emitter, 'event', {
+    timeout: 1000
+}).then(null, function(err){
+    console.log(err); // Error: timeout
+});
+````
+The library promise cancellation API:
+````javascript
+promise= EventEmitter2.once(emitter, 'event');
+// notice: the cancel method exists only in the first promise chain
+promise.then(null, function(err){
+    console.log(err); // Error: canceled
+});
+
+promise.cancel();
+````
+Using the custom Promise class (**[bluebird.js](https://www.npmjs.com/package/bluebird)**):
+````javascript
+var BBPromise = require("bluebird");
+
+EventEmitter2.once(emitter, 'event', {
+    Promise: BBPromise
+}).then(function(data){
+    console.log(data); // [4, 5, 6]
+});
+
+emitter.emit('event', 4, 5, 6);
+````
+
+````javascript
+var BBPromise = require("bluebird");
+
+BBPromise.config({
+    // if false or options.overload enabled, the library cancellation API will be used
+    cancellation: true 
+});
+
+var promise= EventEmitter2.once(emitter, 'event', {
+    Promise: BBPromise,
+    overload: false // use bluebird cancellation API
+}).then(function(data){
+    // notice: never executed due to BlueBird cancellation logic
+}, function(err){
+    // notice: never executed due to BlueBird cancellation logic
+});
+
+promise.cancel();
+
+emitter.emit('event', 'never handled');
+````
+
+

--- a/README.md
+++ b/README.md
@@ -379,13 +379,13 @@ emitter.emit('event', 'foo', 'bar')
 ````
 
 ````javascript
-var thenable= emitter.waitFor('event');
+var promise= emitter.waitFor('event');
 
-thenable.then(null, function(error){
+promise.then(null, function(error){
     console.log(error); //Error: canceled
 });
 
-thenable.cancel(); //stop listening the event and reject the promise
+promise.cancel(); //stop listening the event and reject the promise
 ````
 
 ````javascript

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
 # DESCRIPTION
 
 ### FEATURES
- - Namespaces/Wildcards.
- - Times To Listen (TTL), extends the `once` concept with `many`.
- - Browser environment compatibility.
+ - Namespaces/Wildcards
+ - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent-timestolisten-listener)
+ - The [emitAsync](#emitteremitasyncevent-arg1-arg2-) method to return the results of the listeners via Promise.all
+ - Feature-rich [waitFor](#emitterwaitforevent-options) method to wait for events using promises
+ - Extended version of the [events.once](#eventemitter2onceemitter-name-options) method from the [node events API](https://nodejs.org/api/events.html#events_events_once_emitter_name)
+ - Browser & Workers environment compatibility
  - Demonstrates good performance in benchmarks
 
 ```

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -106,7 +106,7 @@ export declare class EventEmitter2 {
     removeAllListeners(event?: string | eventNS): this;
     setMaxListeners(n: number): void;
     eventNames(): string[];
-    listeners(event: string | string[]): Listener[] // TODO: not in documentation by Willian
+    listeners(event: string | string[]): Listener[]
     listenersAny(): Listener[] // TODO: not in documentation by Willian
     waitFor(event: string, timeout?: number): CancelablePromise<any[]>
     waitFor(event: string, filter?: WaitForFilter): CancelablePromise<any[]>

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -43,6 +43,8 @@ export interface EventAndListener {
     (event: string | string[], ...values: any[]): void;
 }
 
+interface WaitForFilter { (...values: any[]): boolean }
+
 export interface WaitForOptions {
     /**
      * @default 0
@@ -51,14 +53,22 @@ export interface WaitForOptions {
     /**
      * @default null
      */
-    filter: { (...values: any[]): boolean },
+    filter: WaitForFilter,
     /**
      * @default false
      */
-    handleError: boolean
+    handleError: boolean,
+    /**
+     * @default Promise
+     */
+    Promise: Function,
+    /**
+     * @default false
+     */
+    overload: boolean
 }
 
-export interface WaitForThenable<T> extends Promise<T>{
+export interface CancelablePromise<T> extends Promise<T>{
     cancel(reason: string): undefined
 }
 
@@ -74,10 +84,8 @@ export interface OnceOptions {
     /**
      * @default false
      */
-    overload: boolean,
+    overload: boolean
 }
-
-
 
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
@@ -100,6 +108,8 @@ export declare class EventEmitter2 {
     eventNames(): string[];
     listeners(event: string | string[]): Listener[] // TODO: not in documentation by Willian
     listenersAny(): Listener[] // TODO: not in documentation by Willian
-    waitFor(event: string, options?: WaitForOptions): WaitForThenable<any>
-    static once(emitter: EventEmitter2, event: string | symbol, options?: OnceOptions): Promise<any[]>
+    waitFor(event: string, timeout?: number): CancelablePromise<any[]>
+    waitFor(event: string, filter?: WaitForFilter): CancelablePromise<any[]>
+    waitFor(event: string, options?: WaitForOptions): CancelablePromise<any[]>
+    static once(emitter: EventEmitter2, event: string | symbol, options?: OnceOptions): CancelablePromise<any[]>
 }

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -62,6 +62,23 @@ export interface WaitForThenable<T> extends Promise<T>{
     cancel(reason: string): undefined
 }
 
+export interface OnceOptions {
+    /**
+     * @default 0
+     */
+    timeout: number,
+    /**
+     * @default Promise
+     */
+    Promise: Function,
+    /**
+     * @default false
+     */
+    overload: boolean,
+}
+
+
+
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
     emit(event: string | string[], ...values: any[]): boolean;
@@ -84,4 +101,5 @@ export declare class EventEmitter2 {
     listeners(event: string | string[]): Listener[] // TODO: not in documentation by Willian
     listenersAny(): Listener[] // TODO: not in documentation by Willian
     waitFor(event: string, options?: WaitForOptions): WaitForThenable<any>
+    static once(emitter: EventEmitter2, event: string | symbol, options?: OnceOptions): Promise<any[]>
 }

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -122,6 +122,13 @@
     return value;
   }
 
+  function functionReducer(value, reject) {
+    if (typeof value !== 'function') {
+      reject('Promise option must be a function');
+    }
+    return value;
+  }
+
   function toCancelablePromise(Promise, executor, options) {
     var isCancelable;
     var callbacks;
@@ -919,60 +926,47 @@
 
   EventEmitter.prototype.waitFor = function (event, options) {
     var self = this;
-    var handleError = options && options.handleError !== undefined ? options.handleError : false;
-    var filter = options && options.filter !== undefined ? options.filter : false;
-    var timeout = options && options.timeout !== undefined ? options.timeout : 0;
-    var cancel;
+    var type = typeof options;
+    if (type === 'number') {
+      options = {timeout: options};
+    } else if (type === 'function') {
+      options = {filter: options};
+    }
 
-    var promise = new Promise(function (resolve, reject) {
-      var detached;
-      var isDone;
-      var timer = timeout > 0 && setTimeout(function () {
-        timer = 0;
-        done(new Error('timeout'))
-      }, timeout);
+    options= resolveOptions(options, {
+      timeout: 0,
+      filter: undefined,
+      handleError: false,
+      Promise: Promise,
+      overload: false
+    }, {
+      filter: functionReducer,
+      Promise: constructorReducer
+    });
 
-      function done(err, data) {
-        if (isDone) return;
-        isDone = true;
-        !detached && self.off(event, listener);
-        detached = true;
-        timer && clearTimeout(timer);
-        timer = 0;
-        err ? reject(err) : resolve(data);
-      }
-
+    return toCancelablePromise(options.Promise, function (resolve, reject, onCancel) {
       function listener() {
+        var filter= options.filter;
         if (filter && !filter.apply(self, arguments)) {
           return;
         }
-        if (handleError) {
+        if (options.handleError) {
           var err = arguments[0];
-          err ? done(err) : done(null, toArray.apply(null, arguments).slice(1));
+          err ? reject(err) : resolve(toArray.apply(null, arguments).slice(1));
         } else {
-          done(null, toArray.apply(null, arguments));
+          resolve(toArray.apply(null, arguments));
         }
       }
 
-      cancel = function (reason) {
-        done(new Error(reason || 'canceled'))
-      };
+      onCancel(function(){
+        self.off(event, listener);
+      });
 
       self._on(event, listener, false);
-    });
-
-    return Object.create(self, {
-      then: {
-        value: function (resolve, reject) {
-          return promise.then(resolve, reject);
-        }
-      },
-      cancel: {
-        value: function () {
-          cancel && cancel();
-        }
-      }
-    });
+    }, {
+      timeout: options.timeout,
+      overload: options.overload
+    })
   };
 
   function once(emitter, name, options) {
@@ -994,7 +988,7 @@
         };
 
         onCancel(function(){
-          emitter.removeListener(name, handler);
+          emitter.removeEventListener(name, handler);
         });
 
         emitter.addEventListener(

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -129,7 +129,7 @@
     return value;
   }
 
-  function toCancelablePromise(Promise, executor, options) {
+  function makeCancelablePromise(Promise, executor, options) {
     var isCancelable;
     var callbacks;
     var timer= 0;
@@ -944,7 +944,7 @@
       Promise: constructorReducer
     });
 
-    return toCancelablePromise(options.Promise, function (resolve, reject, onCancel) {
+    return makeCancelablePromise(options.Promise, function (resolve, reject, onCancel) {
       function listener() {
         var filter= options.filter;
         if (filter && !filter.apply(self, arguments)) {
@@ -980,7 +980,7 @@
 
     var _Promise= options.Promise;
 
-    return toCancelablePromise(_Promise, function(resolve, reject, onCancel){
+    return makeCancelablePromise(_Promise, function(resolve, reject, onCancel){
       var handler;
       if (typeof emitter.addEventListener === 'function') {
         handler=  function () {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -782,7 +782,8 @@
     module.exports = EventEmitter;
   }
   else {
-    // Browser global.
-    window.EventEmitter2 = EventEmitter;
+    // global for any kind of environment.
+    var _global= new Function('','return this')();
+    _global.EventEmitter2 = EventEmitter;
   }
 }();

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  */
 ;!function(undefined) {
-
+  var hasOwnProperty= Object.hasOwnProperty;
   var isArray = Array.isArray ? Array.isArray : function _isArray(obj) {
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
@@ -83,6 +83,132 @@
         return arr;
     }
   };
+
+  function resolveOptions(options, schema, reducers, allowUnknown) {
+    var computedOptions = Object.assign({}, schema);
+
+    if(!options) return computedOptions;
+
+    if (typeof options !== 'object') {
+      throw TypeError('options must be an object')
+    }
+
+    var keys = Object.keys(options);
+    var length = keys.length;
+    var option, value;
+    var reducer;
+
+    function reject(reason){
+      throw Error('Invalid "' + option + '" option value' + (reason? '. Reason: '+ reason : ''))
+    }
+    for (var i = 0; i < length; i++) {
+      option = keys[i];
+      if (!allowUnknown && !hasOwnProperty.call(schema, option)) {
+        throw Error('Unknown "' + option + '" option');
+      }
+      value = options[option];
+      if (value !== undefined) {
+        reducer = reducers[option];
+        computedOptions[option] = reducer ? reducer(value, reject) : value;
+      }
+    }
+    return computedOptions;
+  }
+
+  function constructorReducer(value, reject) {
+    if (typeof value !== 'function' || !value.hasOwnProperty('prototype')) {
+      reject('Promise option must be a constructor');
+    }
+    return value;
+  }
+
+  function toCancelablePromise(Promise, executor, options) {
+    var isCancelable;
+    var callbacks;
+    var timer= 0;
+    var subscribeClosed;
+
+    var promise = new Promise(function (resolve, reject, onCancel) {
+      options= resolveOptions(options, {
+        timeout: 0,
+        overload: false
+      }, {
+        timeout: function(value, reject){
+          value*= 1;
+          if (typeof value !== 'number' || value < 0 || !Number.isFinite(value)) {
+            reject('timeout must be a positive number');
+          }
+          return value;
+        }
+      });
+
+      isCancelable = !options.overload && typeof Promise.prototype.cancel === 'function' && typeof onCancel === 'function';
+
+      function cleanup() {
+        if (callbacks) {
+          callbacks = null;
+        }
+        if (timer) {
+          clearTimeout(timer);
+          timer = 0;
+        }
+      }
+
+      var _resolve= function(value){
+        cleanup();
+        resolve(value);
+      };
+
+      var _reject= function(err){
+        cleanup();
+        reject(err);
+      };
+
+      if (isCancelable) {
+        executor(_resolve, _reject, onCancel);
+      } else {
+        callbacks = [function(reason){
+          _reject(reason || Error('canceled'));
+        }];
+        executor(_resolve, _reject, function (cb) {
+          if (subscribeClosed) {
+            throw Error('Unable to subscribe on cancel event asynchronously')
+          }
+          if (typeof cb !== 'function') {
+            throw TypeError('onCancel callback must be a function');
+          }
+          callbacks.push(cb);
+        });
+        subscribeClosed= true;
+      }
+
+      if (options.timeout > 0) {
+        timer= setTimeout(function(){
+          var reason= Error('timeout');
+          timer= 0;
+          promise.cancel(reason);
+          reject(reason);
+        }, options.timeout);
+      }
+    });
+
+    if (!isCancelable) {
+      promise.cancel = function (reason) {
+        if (!callbacks) {
+          return;
+        }
+        var length = callbacks.length;
+        for (var i = 1; i < length; i++) {
+          callbacks[i](reason);
+        }
+        // internal callback to reject the promise
+        callbacks[0](reason);
+        callbacks = null;
+      };
+    }
+
+    return promise;
+  }
 
   function EventEmitter(conf) {
     this._events = {};
@@ -290,11 +416,11 @@
 
   EventEmitter.prototype.many = function(event, ttl, fn) {
     return this._many(event, ttl, fn, false);
-  }
+  };
 
   EventEmitter.prototype.prependMany = function(event, ttl, fn) {
     return this._many(event, ttl, fn, true);
-  }
+  };
 
   EventEmitter.prototype._many = function(event, ttl, fn, prepend) {
     var self = this;
@@ -560,7 +686,7 @@
     }
 
     return this;
-  }
+  };
 
   EventEmitter.prototype._on = function(type, listener, prepend) {
     if (typeof type === 'function') {
@@ -612,7 +738,7 @@
     }
 
     return this;
-  }
+  };
 
   EventEmitter.prototype.off = function(type, listener) {
     if (typeof listener !== 'function') {
@@ -774,7 +900,7 @@
 
   EventEmitter.prototype.eventNames = function(){
     return Object.keys(this._events);
-  }
+  };
 
   EventEmitter.prototype.listenerCount = function(type) {
     return this.listeners(type).length;
@@ -848,6 +974,94 @@
       }
     });
   };
+
+  function once(emitter, name, options) {
+    options= resolveOptions(options, {
+      Promise: Promise,
+      timeout: 0,
+      overload: false
+    }, {
+      Promise: constructorReducer
+    });
+
+    var _Promise= options.Promise;
+
+    return toCancelablePromise(_Promise, function(resolve, reject, onCancel){
+      var handler;
+      if (typeof emitter.addEventListener === 'function') {
+        handler=  function () {
+          resolve(toArray.apply(null, arguments));
+        };
+
+        onCancel(function(){
+          emitter.removeListener(name, handler);
+        });
+
+        emitter.addEventListener(
+            name,
+            handler,
+            {once: true}
+        );
+        return;
+      }
+
+      var eventListener = function(){
+        errorListener && emitter.removeListener('error', errorListener);
+        resolve(toArray.apply(null, arguments));
+      };
+
+      var errorListener;
+
+      if (name !== 'error') {
+        errorListener = function (err){
+          emitter.removeListener(name, eventListener);
+          reject(err);
+        };
+
+        emitter.once('error', errorListener);
+      }
+
+      onCancel(function(){
+        errorListener && emitter.removeListener('error', errorListener);
+        emitter.removeListener(name, eventListener);
+      });
+
+      emitter.once(name, eventListener);
+    }, {
+      timeout: options.timeout,
+      overload: options.overload
+    });
+  }
+
+  var prototype= EventEmitter.prototype;
+
+  Object.defineProperties(EventEmitter, {
+    defaultMaxListeners: {
+      get: function () {
+        return prototype._maxListeners;
+      },
+      set: function (n) {
+        if (typeof n !== 'number' || n < 0 || Number.isNaN(n)) {
+          throw TypeError('n must be a non-negative number')
+        }
+        prototype._maxListeners = n;
+      },
+      enumerable: true
+    },
+    once: {
+      value: once,
+      writable: true,
+      configurable: true
+    }
+  });
+
+  Object.defineProperties(prototype, {
+      _maxListeners: {
+          value: defaultMaxListeners,
+          writable: true,
+          configurable: true
+      }
+  });
 
   if (typeof define === 'function' && define.amd) {
      // AMD. Register as an anonymous module.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventemitter2",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL and browser support.",
   "keywords": [
     "event",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "repository": "git://github.com/hij1nx/EventEmitter2.git",
   "devDependencies": {
     "benchmark": ">= 0.2.2",
+    "bluebird": "^3.7.2",
     "nodeunit": "*",
     "nyc": "^11.4.1"
   },

--- a/test/simple/once.js
+++ b/test/simple/once.js
@@ -1,0 +1,164 @@
+var BBPromise = require("bluebird");
+var simpleEvents = require('nodeunit').testCase;
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+BBPromise.config({
+    cancellation: true
+});
+
+if (typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+} else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports = simpleEvents({
+    '1. should return a Promise': function (test) {
+        var ee = new EventEmitter2();
+        var result = EventEmitter2.once(ee, 'event');
+        test.ok(result instanceof Promise);
+        test.done();
+    },
+
+    '2. should resolve the promise when a specific event occurs': function (test) {
+        var ee = new EventEmitter2();
+        var timer = setTimeout(function () {
+            throw Error('timeout');
+        }, 100);
+        EventEmitter2.once(ee, 'event').then(function () {
+            clearTimeout(timer);
+            test.done();
+        }, function (err) {
+            clearTimeout(timer);
+            throw err;
+        });
+        ee.emit('event');
+    },
+
+    '3. should handle the event data arguments as an array': function (test) {
+        var ee = new EventEmitter2();
+        EventEmitter2.once(ee, 'event').then(function (data) {
+            test.deepEqual(data, [1, 2, 3]);
+            test.done();
+        }, function (err) {
+            throw err;
+        });
+        ee.emit('event', 1, 2, 3);
+    },
+
+    '4. should reject the promise if an error event emitted': function (test) {
+        var ee = new EventEmitter2();
+        var message = 'test';
+        var timer = setTimeout(function () {
+            throw Error('timeout');
+        }, 100);
+        EventEmitter2.once(ee, 'event').then(function () {
+            clearTimeout(timer);
+            throw Error('unexpected promise resolving');
+        }, function (err) {
+            clearTimeout(timer);
+            test.equal(err.message, message);
+            test.done();
+        });
+        ee.emit('error', new Error(message));
+    },
+
+    '5. should support cancellation': function (test) {
+        var ee = new EventEmitter2();
+        var message = 'canceled';
+
+        var timer = setTimeout(function () {
+            throw Error('test timeout');
+        }, 100);
+        var promise = EventEmitter2.once(ee, 'event');
+
+        promise.then(function () {
+            clearTimeout(timer);
+            throw Error('unexpected promise resolving');
+        }, function (err) {
+            clearTimeout(timer);
+            test.equal(err.message, message);
+            test.done();
+        });
+
+        setTimeout(function () {
+            promise.cancel();
+        }, 50);
+    },
+
+    '6. should support timeout handling': function (test) {
+        var ee = new EventEmitter2();
+        var message = 'timeout';
+
+        var timer = setTimeout(function () {
+            throw Error('test timeout');
+        }, 100);
+
+        var promise = EventEmitter2.once(ee, 'event', {
+            timeout: 10
+        });
+
+        promise.then(function () {
+            clearTimeout(timer);
+            throw Error('unexpected promise resolving');
+        }, function (err) {
+            clearTimeout(timer);
+            test.equal(err.message, message);
+            test.done();
+        });
+    },
+
+
+    '7. should support BlueBird promises': function (test) {
+        var ee = new EventEmitter2();
+
+        EventEmitter2.once(ee, 'event', {
+            Promise: BBPromise
+        }).then(function (data) {
+            test.deepEqual(data, [1, 2, 3]);
+            test.done();
+        }, function (err) {
+            throw err;
+        });
+        ee.emit('event', 1, 2, 3);
+    },
+
+    '8. should support BlueBird promise silent cancellation': function (test) {
+        var ee = new EventEmitter2();
+
+        var bbPromise= EventEmitter2.once(ee, 'event', {
+            Promise: BBPromise
+        }).then(function () {
+            throw Error('unexpected promise resolving');
+        }, function () {
+            throw Error('unexpected promise rejecting');
+        });
+
+        bbPromise.cancel();
+        ee.emit('event');
+
+        setTimeout(function(){
+            test.done();
+        }, 50);
+    },
+
+    '9. should support overloading cancellation api': function (test) {
+        var ee = new EventEmitter2();
+        var message= 'canceled';
+
+        var bbPromise= EventEmitter2.once(ee, 'event', {
+            Promise: BBPromise,
+            overload: true
+        });
+
+        bbPromise.then(function () {
+            throw Error('unexpected promise resolving');
+        }, function (err) {
+            test.equal(err.message, message);
+            test.done();
+        });
+
+        bbPromise.cancel();
+    }
+});


### PR DESCRIPTION
1) Added an extended version of node's events.once method.
```
var emitter= new EventEmitter2();

var promise= EventEmitter2.once(emitter, 'event', {
    timeout: 0,
    Promise: Promise, // a custom Promise constructor
    overload: false // overload promise cancellation api if exists with library implementation
})

promise.then(function(data){
    console.log(data); // [1, 2, 3]
});
// promise.cancel()
emitter.emit('event', 1, 2, 3);
```

2) Added generic internals:
- resolveOptions() to compute & validate an options object
- toCancelablePromise() to make some promise cancellable with timeout & overload options

3) Reworked emitter.waitFor method to use shared internals (saved the previous interface).
4) Added new overloads/shortcuts for the emitter.waitFor method:
- emitter.waitFor(event, [timeout])
- emitter.waitFor(event, [filter])
5) Added new options for the emitter.waitFor method (same as the 'events.once' method has):
- Promise
- overload
