### PR TITLE
Closes #162 normalize event names for listeners when emitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ npm-debug.log
 .idea
 .nyc_output
 coverage
+
+package-lock.json

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -1,4 +1,6 @@
-export type eventNS = string[];
+export type eventNS = (symbol|string)[];
+export type event = (symbol|string);
+
 export interface ConstructorOptions {
     /**
      * @default false
@@ -89,29 +91,29 @@ export interface OnceOptions {
 
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
-    emit(event: string | string[], ...values: any[]): boolean;
-    emitAsync(event: string | string[], ...values: any[]): Promise<any[]>;
-    addListener(event: string, listener: Listener): this;
-    on(event: string | string[], listener: Listener): this;
-    prependListener(event: string | string[], listener: Listener): this;
-    once(event: string | string[], listener: Listener): this;
-    prependOnceListener(event: string | string[], listener: Listener): this;
-    many(event: string | string[], timesToListen: number, listener: Listener): this;
-    prependMany(event: string | string[], timesToListen: number, listener: Listener): this;
+    emit(event: event | eventNS, ...values: any[]): boolean;
+    emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
+    addListener(event: event | eventNS, listener: Listener): this;
+    on(event: event | eventNS, listener: Listener): this;
+    prependListener(event: event | eventNS, listener: Listener): this;
+    once(event: event | eventNS, listener: Listener): this;
+    prependOnceListener(event: event | eventNS, listener: Listener): this;
+    many(event: event | eventNS, timesToListen: number, listener: Listener): this;
+    prependMany(event: event | eventNS, timesToListen: number, listener: Listener): this;
     onAny(listener: EventAndListener): this;
     prependAny(listener: EventAndListener): this;
     offAny(listener: Listener): this;
-    removeListener(event: string | string[], listener: Listener): this;
-    off(event: string, listener: Listener): this;
-    removeAllListeners(event?: string | eventNS): this;
+    removeListener(event: event | eventNS, listener: Listener): this;
+    off(event: event | eventNS, listener: Listener): this;
+    removeAllListeners(event?: event | eventNS): this;
     setMaxListeners(n: number): void;
     getMaxListeners(): number;
     eventNames(): string[];
-    listeners(event: string | string[]): Listener[]
+    listeners(event: event | eventNS): Listener[]
     listenersAny(): Listener[] // TODO: not in documentation by Willian
-    waitFor(event: string, timeout?: number): CancelablePromise<any[]>
-    waitFor(event: string, filter?: WaitForFilter): CancelablePromise<any[]>
-    waitFor(event: string, options?: WaitForOptions): CancelablePromise<any[]>
-    static once(emitter: EventEmitter2, event: string | symbol, options?: OnceOptions): CancelablePromise<any[]>
+    waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>
+    waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>
+    waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>
+    static once(emitter: EventEmitter2, event: event | eventNS, options?: OnceOptions): CancelablePromise<any[]>
     static defaultMaxListeners: number;
 }

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -462,12 +462,21 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0];
+    var type = arguments[0], ns, wildcard= this.wildcard;
 
     if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
         return false;
       }
+    }
+
+    if(wildcard){
+        if (typeof type === 'string') {
+            ns = type.split(this.delimiter);
+        } else {
+            ns = type.slice();
+            type = type.join(this.delimiter);
+        }
     }
 
     var al = arguments.length;
@@ -499,9 +508,8 @@
       }
     }
 
-    if (this.wildcard) {
+    if (wildcard) {
       handler = [];
-      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
     } else {
       handler = this._events[type];
@@ -570,10 +578,19 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0];
+    var type = arguments[0], wildcard= this.wildcard, ns;
 
     if (type === 'newListener' && !this._newListener) {
         if (!this._events.newListener) { return Promise.resolve([false]); }
+    }
+
+    if(wildcard){
+        if (typeof type === 'string') {
+            ns = type.split(this.delimiter);
+        } else {
+            ns = type.slice();
+            type = type.join(this.delimiter);
+        }
     }
 
     var promises= [];
@@ -605,9 +622,8 @@
       }
     }
 
-    if (this.wildcard) {
+    if (wildcard) {
       handler = [];
-      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
     } else {
       handler = this._events[type];

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -417,9 +417,8 @@
     this.verboseMemoryLeak = false;
     configure.call(this, conf);
   }
+
   EventEmitter.EventEmitter2 = EventEmitter; // backwards compatibility for exporting EventEmitter property
-
-
 
   // By default EventEmitters will print a warning if more than
   // 10 listeners are added to it. This is a useful default which
@@ -493,7 +492,8 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0], ns, wildcard= this.wildcard;
+    var type = arguments[0], ns, wildcard= this.wildcard, kind;
+    var args,l,i,j, containsSymbol;
 
     if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
@@ -501,17 +501,32 @@
       }
     }
 
-    if(wildcard){
-        if (typeof type === 'string') {
-            ns = type.split(this.delimiter);
-        } else {
-            ns = type.slice();
+    if (wildcard) {
+      kind = typeof type;
+      if (kind === 'string') {
+        ns = type.split(this.delimiter);
+      } else {
+        if(kind==='symbol'){
+          ns= [type];
+        }else{
+          ns = type.slice();
+          l= type.length;
+          if(supportSymbols) {
+            for (i = 0; i < l; i++) {
+              if (typeof type[i] === 'symbol') {
+                containsSymbol = true;
+                break;
+              }
+            }
+          }
+          if(!containsSymbol){
             type = type.join(this.delimiter);
+          }
         }
+      }
     }
 
     var al = arguments.length;
-    var args,l,i,j;
     var handler;
 
     if (this._all && this._all.length) {
@@ -609,25 +624,41 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0], wildcard= this.wildcard, ns;
+    var type = arguments[0], wildcard= this.wildcard, ns, kind, containsSymbol;
+    var args,l,i,j;
 
     if (type === 'newListener' && !this._newListener) {
         if (!this._events.newListener) { return Promise.resolve([false]); }
     }
 
-    if(wildcard){
-        if (typeof type === 'string') {
-            ns = type.split(this.delimiter);
-        } else {
-            ns = type.slice();
+    if (wildcard) {
+      kind = typeof type;
+      if (kind === 'string') {
+        ns = type.split(this.delimiter);
+      } else {
+        if(kind==='symbol'){
+          ns= [type];
+        }else{
+          ns = type.slice();
+          l= type.length;
+          if(supportSymbols) {
+            for (i = 0; i < l; i++) {
+              if (typeof type[i] === 'symbol') {
+                containsSymbol = true;
+                break;
+              }
+            }
+          }
+          if(!containsSymbol){
             type = type.join(this.delimiter);
+          }
         }
+      }
     }
 
     var promises= [];
 
     var al = arguments.length;
-    var args,l,i,j;
     var handler;
 
     if (this._all) {
@@ -901,7 +932,7 @@
 
   EventEmitter.prototype.removeListener = EventEmitter.prototype.off;
 
-  EventEmitter.prototype.removeAllListeners = function(type) {
+  EventEmitter.prototype.removeAllListeners = function (type) {
     if (type === undefined) {
       !this._events || init.call(this);
       return this;
@@ -911,12 +942,11 @@
       var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       var leafs = searchListenerTree.call(this, null, ns, this.listenerTree, 0);
 
-      for (var iLeaf=0; iLeaf<leafs.length; iLeaf++) {
+      for (var iLeaf = 0; iLeaf < leafs.length; iLeaf++) {
         var leaf = leafs[iLeaf];
         leaf._listeners = null;
       }
-    }
-    else if (this._events) {
+    } else if (this._events) {
       this._events[type] = null;
     }
     return this;

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -782,7 +782,8 @@
     module.exports = EventEmitter;
   }
   else {
-    // Browser global.
-    window.EventEmitter2 = EventEmitter;
+    // global for any kind of environment.
+    var _global= new Function('','return this')();
+    _global.EventEmitter2 = EventEmitter;
   }
 }();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventemitter2",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL and browser support.",
   "keywords": [
     "event",

--- a/test/wildcardEvents/normalizeEvent.js
+++ b/test/wildcardEvents/normalizeEvent.js
@@ -1,0 +1,52 @@
+var assert= require('assert');
+
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports= {
+    'should normalize event name when emitting an event': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(typeof this.event==='string');
+            assert.equal(this.event, 'event.test');
+            counter++;
+        });
+
+        ee.emit('event.test');
+        ee.emit(['event', 'test']);
+        assert.equal(counter, 2, 'event not fired');
+    },
+
+    'should normalize event name when emitting an event in async mode': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(typeof this.event==='string');
+            assert.equal(this.event, 'event.test');
+            counter++;
+        });
+
+        return Promise.all([
+            ee.emitAsync('event.test'),
+            ee.emitAsync(['event', 'test'])
+        ]).then(function(){
+            assert.equal(counter, 2, 'event not fired');
+        });
+    }
+};

--- a/test/wildcardEvents/normalizeEvent.js
+++ b/test/wildcardEvents/normalizeEvent.js
@@ -48,5 +48,42 @@ module.exports= {
         ]).then(function(){
             assert.equal(counter, 2, 'event not fired');
         });
+    },
+
+    'should not convert ns to a string if ns is an array and contains a symbol': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+        var symbol= Symbol('test');
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(Array.isArray(this.event));
+            assert.deepEqual(this.event, ['event', symbol]);
+            counter++;
+        });
+
+        ee.emit(['event', symbol]);
+        assert.equal(counter, 1, 'event not fired');
+    },
+
+    'should not convert ns to a string if ns is an array and contains a symbol while emitting in async mode': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+        var symbol= Symbol('test');
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(Array.isArray(this.event));
+            assert.deepEqual(this.event, ['event', symbol]);
+            counter++;
+        });
+
+        return Promise.all([
+            ee.emit(['event', symbol])
+        ]).then(function(){
+            assert.equal(counter, 1, 'event not fired');
+        });
     }
 };


### PR DESCRIPTION
Now this.event is always a string in wildcard mode. For non-wildcard mode normalization is not used, as it was before.