### PR TITLE
Feat/async listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ or process.nextTick depending on the `nextTick` option.
 This option will be activated by default if its value is `undefined`
 and the listener function is an `asynchronous function` (whose constructor name is `AsyncFunction`). 
 
-If the options argument is `true` it will be considered as `{promisify: true}`
+**Note:** If the options argument is `true` it will be considered as `{promisify: true}`
 
-If the options argument is `false` it will be considered as `{async: true}`
+**Note:** If the options argument is `false` it will be considered as `{async: true}`
 
 ```javascript
 var EventEmitter2= require('eventemitter2');

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
 
 ### FEATURES
  - Namespaces/Wildcards
- - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent-timestolisten-listener)
+ - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent--eventns-timestolisten-listener-options)
  - [Async listeners](#emitteronevent-listener-options-objectboolean) (using setImmediate|setTimeout|nextTick) with promise|async function support
- - The [emitAsync](#emitteremitasyncevent-arg1-arg2-) method to return the results of the listeners via Promise.all
- - Feature-rich [waitFor](#emitterwaitforevent-options) method to wait for events using promises
- - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event--eventns-string-boolean) methods
+ - The [emitAsync](#emitteremitasyncevent--eventns-arg1-arg2-) method to return the results of the listeners via Promise.all
+ - Feature-rich [waitFor](#emitterwaitforevent--eventns-options) method to wait for events using promises
+ - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event-event--eventns-boolean) methods
  for listening to an external event emitter and propagate its events through itself using optional reducers/filters 
  - Extended version of the [events.once](#eventemitter2onceemitter-event--eventns-options) method from the [node events API](https://nodejs.org/api/events.html#events_events_once_emitter_name)
  - Browser & Workers environment compatibility

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ or process.nextTick depending on the `nextTick` option.
 This option will be activated by default if its value is `undefined`
 and the listener function is an `asynchronous function` (whose constructor name is `AsyncFunction`). 
 
-if the options argument is `true` it will be considered as `{promisify: true}`
+If the options argument is `true` it will be considered as `{promisify: true}`
 
-if the options argument is `false` it will be considered as `{async: true}`
+If the options argument is `false` it will be considered as `{async: true}`
 
 ```javascript
 var EventEmitter2= require('eventemitter2');
@@ -294,6 +294,9 @@ The event was raised!
 If the listener is an async function or function which returns a promise, use the `promisify` option as follows:
 
 ```javascript
+var EventEmitter2= require('eventemitter2');
+var emitter= new EventEmitter2();
+
 emitter.on('event', function(){
     console.log('The event was raised!');
     return new Promise(function(resolve){

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
 ### FEATURES
  - Namespaces/Wildcards
  - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent-timestolisten-listener)
+ - [Async listeners](#emitteronevent-listener-options-objectboolean) (using setImmediate|setTimeout|nextTick) with promise|async function support
  - The [emitAsync](#emitteremitasyncevent-arg1-arg2-) method to return the results of the listeners via Promise.all
  - Feature-rich [waitFor](#emitterwaitforevent-options) method to wait for events using promises
  - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event--eventns-string-boolean) methods
@@ -24,13 +25,14 @@ EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
 ```
 Platform: win32, x64, 15267MB
 Node version: v13.11.0
-Cpu: 4 x AMD Ryzen 3 2200U with Radeon Vega Mobile Gfx @ 2495MHz
+CPU: 4 x AMD Ryzen 3 2200U with Radeon Vega Mobile Gfx @ 2495MHz
 ----------------------------------------------------------------
-EventEmitterHeatUp x 3,017,814 ops/sec ±3.37% (68 runs sampled)
-EventEmitter x 3,357,197 ops/sec ±4.66% (62 runs sampled)
-EventEmitter2 x 11,378,225 ops/sec ±3.99% (62 runs sampled)
-EventEmitter2 (wild) x 4,799,373 ops/sec ±4.01% (66 runs sampled)
-EventEmitter3 x 10,007,114 ops/sec ±3.94% (69 runs sampled)
+EventEmitterHeatUp x 3,167,076 ops/sec ±3.17% (59 runs sampled)
+EventEmitter x 3,190,460 ops/sec ±3.20% (66 runs sampled)
+EventEmitter2 x 11,278,456 ops/sec ±4.26% (60 runs sampled)
+EventEmitter2 (wild) x 4,620,369 ops/sec ±4.46% (61 runs sampled)
+EventEmitter3 x 10,309,717 ops/sec ±3.89% (64 runs sampled)
+
 Fastest is EventEmitter2
 ```
 
@@ -273,10 +275,54 @@ if the options arguments is `true` it will be considered as `{promisify: true}`
 if the options arguments is `false` it will be considered as `{async: true}`
 
 ```javascript
-server.on('data', function(value) {
-  console.log('The event was raised!');
+var EventEmitter2= require('eventemitter2');
+var emitter= new EventEmitter2();
+
+emitter.on('event', function(){
+    console.log('The event was raised!');
 }, {async: true});
+
+emitter.emit('event');
+console.log('emitted');
 ```
+Since the `async` option was set the output from the code above is as follows:
+````
+emitted
+The event was raised!
+````
+
+If the listener is an async function or function which returns a promise, use the `promisify` option as follows:
+
+```javascript
+emitter.on('event', function(){
+    console.log('The event was raised!');
+    return new Promise(function(resolve){
+       console.log('listener resolved');
+       setTimeout(resolve, 1000);
+    });
+}, {promisify: true});
+
+emitter.emitAsync('event').then(function(){
+    console.log('all listeners were resolved!');
+});
+
+console.log('emitted');
+````
+Output:
+````
+emitted
+The event was raised!
+listener resolved
+all listeners were resolved!
+````
+If the `promisify` option is false (default value) the output of the same code is as follows:
+````
+The event was raised!
+listener resolved
+emitted
+all listeners were resolved!
+````
+
 
 ### emitter.prependListener(event, listener, options?)
 

--- a/README.md
+++ b/README.md
@@ -121,29 +121,29 @@ $ npm install eventemitter2
 
 - [emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>](#emitteremitasyncevent--eventns-arg1-arg2-)
 
-- [addListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener-options-objectboolean)
+- [addListener(event: event | eventNS, listener: ListenerFn, boolean|options?: object): this|Listener](#emitteraddlistenerevent-listener-options-objectboolean)
 
-- [on(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener-options-objectboolean)
+- [on(event: event | eventNS, listener: ListenerFn, boolean|options?: object): this|Listener](#emitteraddlistenerevent-listener-options-objectboolean)
 
-- [once(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteronceevent--eventns-listener-options)
+- [once(event: event | eventNS, listener: ListenerFn, boolean|options?: object): this|Listener](#emitteronceevent--eventns-listener-options)
 
-- [many(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emittermanyevent--eventns-timestolisten-listener-options)
+- [many(event: event | eventNS, timesToListen: number, listener: ListenerFn, boolean|options?: object): this|Listener](#emittermanyevent--eventns-timestolisten-listener-options)
 
-- [prependMany(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emitterprependanylistener)
+- [prependMany(event: event | eventNS, timesToListen: number, listener: ListenerFn, boolean|options?: object): this|Listener](#emitterprependanylistener)
 
-- [prependOnceListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependoncelistenerevent--eventns-listener-options)
+- [prependOnceListener(event: event | eventNS, listener: ListenerFn, boolean|options?: object): this|Listener](#emitterprependoncelistenerevent--eventns-listener-options)
 
-- [prependListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependlistenerevent-listener-options)
+- [prependListener(event: event | eventNS, listener: ListenerFn, boolean|options?: object): this|Listener](#emitterprependlistenerevent-listener-options)
 
 - [prependAny(listener: EventAndListener): this](#emitterprependanylistener)
 
 - [onAny(listener: EventAndListener): this](#emitteronanylistener)
 
-- [offAny(listener: Listener): this](#emitteroffanylistener)
+- [offAny(listener: ListenerFn): this](#emitteroffanylistener)
 
-- [removeListener(event: event | eventNS, listener: Listener): this](#emitterremovelistenerevent--eventns-listener)
+- [removeListener(event: event | eventNS, listener: ListenerFn): this](#emitterremovelistenerevent--eventns-listener)
 
-- [off(event: event | eventNS, listener: Listener): this](#emitteroffevent--eventns-listener)
+- [off(event: event | eventNS, listener: ListenerFn): this](#emitteroffevent--eventns-listener)
 
 - [removeAllListeners(event?: event | eventNS): this](#emitterremovealllistenersevent--eventns)
 
@@ -153,9 +153,9 @@ $ npm install eventemitter2
 
 - [eventNames(): string[]](#emittereventnames)
 
-- [listeners(event: event | eventNS): Listener[]](#emitterlistenersevent--eventns)
+- [listeners(event: event | eventNS): ListenerFn[]](#emitterlistenersevent--eventns)
 
-- [listenersAny(): Listener[]](#emitterlistenersany)
+- [listenersAny(): ListenerFn[]](#emitterlistenersany)
 
 - [hasListeners(event?: event | eventNS): Boolean](#haslistenersevent--eventnsstringboolean)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
  - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent--eventns-timestolisten-listener-options)
  - [Async listeners](#emitteronevent-listener-options-objectboolean) (using setImmediate|setTimeout|nextTick) with promise|async function support
  - The [emitAsync](#emitteremitasyncevent--eventns-arg1-arg2-) method to return the results of the listeners via Promise.all
+ - Subscription methods ([on](#emitteronevent-listener-options-objectboolean), once, many, ...) can return a 
+ [listener](#listener) object that makes it easy to remove the subscription when needed - just call the listener.off() method.
  - Feature-rich [waitFor](#emitterwaitforevent--eventns-options) method to wait for events using promises
  - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event-event--eventns-boolean) methods
  for listening to an external event emitter and propagate its events through itself using optional reducers/filters 
@@ -123,19 +125,19 @@ $ npm install eventemitter2
 
 - [on(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener-options-objectboolean)
 
-- [prependListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependlistenerevent-listener-options)
-
 - [once(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteronceevent--eventns-listener-options)
-
-- [prependOnceListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependoncelistenerevent--eventns-listener-options)
 
 - [many(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emittermanyevent--eventns-timestolisten-listener-options)
 
 - [prependMany(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emitterprependanylistener)
 
-- [onAny(listener: EventAndListener): this](#emitteronanylistener)
+- [prependOnceListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependoncelistenerevent--eventns-listener-options)
+
+- [prependListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependlistenerevent-listener-options)
 
 - [prependAny(listener: EventAndListener): this](#emitterprependanylistener)
+
+- [onAny(listener: EventAndListener): this](#emitteronanylistener)
 
 - [offAny(listener: Listener): this](#emitteroffanylistener)
 
@@ -155,6 +157,8 @@ $ npm install eventemitter2
 
 - [listenersAny(): Listener[]](#emitterlistenersany)
 
+- [hasListeners(event?: event | eventNS): Boolean](#haslistenersevent--eventnsstringboolean)
+
 - [waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>](#emitterwaitforevent--eventns-timeout)
 
 - [waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>](#emitterwaitforevent--eventns-filter)
@@ -168,8 +172,6 @@ $ npm install eventemitter2
 - [listenTo(target: GeneralEventEmitter, events: Object<event | eventNS, Function>, options?: ListenToOptions): this](#listentotargetemitter-events-objectevent--eventns-function-options)
 
 - [stopListening(target?: GeneralEventEmitter, event?: event | eventNS): Boolean](#stoplisteningtarget-object-event-event--eventns-boolean)
-
-- [hasListeners(event?: event | eventNS): Boolean](#haslistenersevent--eventnsstringboolean)
 
 ### static:
 
@@ -255,6 +257,25 @@ or process.nextTick depending on the `nextTick` option.
 - `promisify:boolean= false`- additionally wraps the listener to a Promise for later invocation using `emitAsync` method.
 This option will be activated by default if its value is `undefined`
 and the listener function is an `asynchronous function` (whose constructor name is `AsyncFunction`). 
+
+- `objectify:boolean= false`- activates returning a [listener](#listener) object instead of 'this' by the subscription method.
+
+#### listener
+The listener object has the following properties:
+- `emitter: EventEmitter2` - reference to the event emitter instance
+- `event: event|eventNS` - subscription event
+- `listener: Function` - reference to the listener
+- `off(): Function`- removes the listener (voids the subscription)
+
+````javascript
+var listener= emitter.on('event', function(){
+  console.log('hello!');
+}, {objectify: true});
+
+emitter.emit('event');
+
+listener.off();
+````
 
 **Note:** If the options argument is `true` it will be considered as `{promisify: true}`
 

--- a/README.md
+++ b/README.md
@@ -131,19 +131,19 @@ $ npm install eventemitter2
 
 - [emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>](#emitteremitasyncevent-arg1-arg2-)
 
-- [addListener(event: event | eventNS, listener: Listener): this](#emitteraddlistenerevent-listener)
+- [addListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener)
 
-- [on(event: event | eventNS, listener: Listener): this](#emitteraddlistenerevent-listener)
+- [on(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener)
 
-- [prependListener(event: event | eventNS, listener: Listener): this](#emitterprependlistenerevent-listener)
+- [prependListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependlistenerevent-listener)
 
-- [once(event: event | eventNS, listener: Listener): this](#emitteronceevent-listener)
+- [once(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteronceevent-listener)
 
-- [prependOnceListener(event: event | eventNS, listener: Listener): this](#emitterprependoncelistenerevent-listener)
+- [prependOnceListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependoncelistenerevent-listener)
 
-- [many(event: event | eventNS, timesToListen: number, listener: Listener): this](#emittermanyevent-timestolisten-listener)
+- [many(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emittermanyevent-timestolisten-listener)
 
-- [prependMany(event: event | eventNS, timesToListen: number, listener: Listener): this](#emitterprependanylistener)
+- [prependMany(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emitterprependanylistener)
 
 - [onAny(listener: EventAndListener): this](#emitteronanylistener)
 
@@ -241,8 +241,8 @@ emitter.emit(['foo', Symbol(), 'baz');
 On the other hand, if the single-wildcard event name was passed to the on method, the callback would only observe the second of these events.
 
 
-### emitter.addListener(event, listener)
-### emitter.on(event, listener)
+### emitter.addListener(event, listener, options?: object|boolean)
+### emitter.on(event, listener, options?: object|boolean)
 
 Adds a listener to the end of the listeners array for the specified event.
 
@@ -251,14 +251,34 @@ server.on('data', function(value1, value2, value3, ...) {
   console.log('The event was raised!');
 });
 ```
-
 ```javascript
 server.on('data', function(value) {
   console.log('The event was raised!');
 });
 ```
 
-### emitter.prependListener(event, listener)
+**Options:**
+
+- `async:boolean= false`- invoke the listener in async mode using setImmediate (or setTimeout if not available)
+or process.nextTick depending on the `nextTick` option.
+
+- `nextTick:boolean= false`- use process.nextTick instead of setImmediate to invoke the listener asynchronously. 
+
+- `promisify:boolean= false`- additionally wraps the listener to a Promise for later invocation using `emitAsync` method.
+This option will be activated by default if its value is `undefined`
+and the listener function is an `asynchronous function` (whose constructor name is `AsyncFunction`). 
+
+if the options arguments is `true` it will be considered as `{promisify: true}`
+
+if the options arguments is `false` it will be considered as `{async: true}`
+
+```javascript
+server.on('data', function(value) {
+  console.log('The event was raised!');
+}, {async: true});
+```
+
+### emitter.prependListener(event, listener, options?)
 
 Adds a listener to the beginning of the listeners array for the specified event.
 
@@ -268,6 +288,9 @@ server.prependListener('data', function(value1, value2, value3, ...) {
 });
 ```
 
+**options:**
+
+`options?`: See the [addListener options](#emitteronevent-listener-options)
 
 ### emitter.onAny(listener)
 
@@ -299,7 +322,7 @@ server.offAny(function(value) {
 });
 ```
 
-#### emitter.once(event | eventNS, listener)
+#### emitter.once(event | eventNS, listener, options?)
 
 Adds a **one time** listener for the event. The listener is invoked 
 only the first time the event is fired, after which it is removed.
@@ -310,7 +333,11 @@ server.once('get', function (value) {
 });
 ```
 
-#### emitter.prependOnceListener(event | eventNS, listener)
+**options:**
+
+`options?`: See the [addListener options](#emitteronevent-listener-options)
+
+#### emitter.prependOnceListener(event | eventNS, listener, options?)
 
 Adds a **one time** listener for the event. The listener is invoked 
 only the first time the event is fired, after which it is removed.
@@ -322,7 +349,11 @@ server.prependOnceListener('get', function (value) {
 });
 ```
 
-### emitter.many(event | eventNS, timesToListen, listener)
+**options:**
+
+`options?`: See the [addListener options](#emitteronevent-listener-options)
+
+### emitter.many(event | eventNS, timesToListen, listener, options?)
 
 Adds a listener that will execute **n times** for the event before being
 removed. The listener is invoked only the first **n times** the event is 
@@ -334,7 +365,11 @@ server.many('get', 4, function (value) {
 });
 ```
 
-### emitter.prependMany(event | eventNS, timesToListen, listener)
+**options:**
+
+`options?`: See the [addListener options](#emitteronevent-listener-options)
+
+### emitter.prependMany(event | eventNS, timesToListen, listener, options?)
 
 Adds a listener that will execute **n times** for the event before being
 removed. The listener is invoked only the first **n times** the event is 
@@ -347,7 +382,9 @@ server.many('get', 4, function (value) {
 });
 ```
 
+**options:**
 
+`options?`: See the [addListener options](#emitteronevent-listener-options)
 
 ### emitter.removeListener(event | eventNS, listener)
 ### emitter.off(event | eventNS, listener)

--- a/README.md
+++ b/README.md
@@ -133,17 +133,17 @@ $ npm install eventemitter2
 
 - [emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>](#emitteremitasyncevent--eventns-arg1-arg2-)
 
-- [addListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener)
+- [addListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener-options-objectboolean)
 
-- [on(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener)
+- [on(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteraddlistenerevent-listener-options-objectboolean)
 
-- [prependListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependlistenerevent-listener)
+- [prependListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependlistenerevent-listener-options)
 
-- [once(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteronceevent-listener)
+- [once(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitteronceevent--eventns-listener-options)
 
-- [prependOnceListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependoncelistenerevent-listener)
+- [prependOnceListener(event: event | eventNS, listener: Listener, boolean|options?: object): this](#emitterprependoncelistenerevent--eventns-listener-options)
 
-- [many(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emittermanyevent-timestolisten-listener)
+- [many(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emittermanyevent--eventns-timestolisten-listener-options)
 
 - [prependMany(event: event | eventNS, timesToListen: number, listener: Listener, boolean|options?: object): this](#emitterprependanylistener)
 
@@ -175,7 +175,7 @@ $ npm install eventemitter2
 
 - [waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>](#emitterwaitforevent--eventns-options)
 
-- [listenTo(target: GeneralEventEmitter, event: event | eventNS, options?: ListenToOptions): this](#listentotargetemitter-events-event--eventns-options)
+- [listenTo(target: GeneralEventEmitter, event: event | eventNS, options?: ListenToOptions): this](#listentotargetemitter-events-objectevent--eventns-function-options)
 
 - [listenTo(target: GeneralEventEmitter, events: (event | eventNS)[], options?: ListenToOptions): this](#listentotargetemitter-events-event--eventns-options)
 

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -118,7 +118,7 @@ export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
     emit(event: event | eventNS, ...values: any[]): boolean;
     emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
-    addListener(event: event | eventNS, listener: ListenerFn): this;
+    addListener(event: event | eventNS, listener: ListenerFn): this|Listener;
     on(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
     prependListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
     once(event: event | eventNS, listener: ListenerFn, options?: true|OnOptions): this|Listener;

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -105,17 +105,23 @@ export interface GeneralEventEmitter{
     removeEventListener: Function
 }
 
+export interface OnOptions {
+    async?: boolean,
+    promisify?: boolean,
+    nextTick?: boolean
+}
+
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
     emit(event: event | eventNS, ...values: any[]): boolean;
     emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
     addListener(event: event | eventNS, listener: Listener): this;
-    on(event: event | eventNS, listener: Listener): this;
-    prependListener(event: event | eventNS, listener: Listener): this;
-    once(event: event | eventNS, listener: Listener): this;
-    prependOnceListener(event: event | eventNS, listener: Listener): this;
-    many(event: event | eventNS, timesToListen: number, listener: Listener): this;
-    prependMany(event: event | eventNS, timesToListen: number, listener: Listener): this;
+    on(event: event | eventNS, listener: Listener, options?: boolean|OnOptions): this;
+    prependListener(event: event | eventNS, listener: Listener, options?: boolean|OnOptions): this;
+    once(event: event | eventNS, listener: Listener, options?: true|OnOptions): this;
+    prependOnceListener(event: event | eventNS, listener: Listener, options?: boolean|OnOptions): this;
+    many(event: event | eventNS, timesToListen: number, listener: Listener, options?: boolean|OnOptions): this;
+    prependMany(event: event | eventNS, timesToListen: number, listener: Listener, options?: boolean|OnOptions): this;
     onAny(listener: EventAndListener): this;
     prependAny(listener: EventAndListener): this;
     offAny(listener: Listener): this;
@@ -125,15 +131,12 @@ export declare class EventEmitter2 {
     setMaxListeners(n: number): void;
     getMaxListeners(): number;
     eventNames(): string[];
-    listeners(event: event | eventNS): Listener[]
-    listenersAny(): Listener[] // TODO: not in documentation by Willian
+    listenerCount(event?: event | eventNS): number
+    listeners(event?: event | eventNS): Listener[]
+    listenersAny(): Listener[]
     waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>
     waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>
     waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>
-    static once(emitter: EventEmitter2, event: event | eventNS, options?: OnceOptions): CancelablePromise<any[]>
-    waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>;
-    waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>;
-    waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>;
     listenTo(target: GeneralEventEmitter, events: event | eventNS, options?: ListenToOptions): this;
     listenTo(target: GeneralEventEmitter, events: (event | eventNS)[], options?: ListenToOptions): this;
     listenTo(target: GeneralEventEmitter, events: Object, options?: ListenToOptions): this;

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -38,7 +38,7 @@ export interface ConstructorOptions {
      */
     ignoreErrors?: boolean
 }
-export interface Listener {
+export interface ListenerFn {
     (...values: any[]): void;
 }
 export interface EventAndListener {
@@ -103,32 +103,40 @@ export interface GeneralEventEmitter{
 export interface OnOptions {
     async?: boolean,
     promisify?: boolean,
-    nextTick?: boolean
+    nextTick?: boolean,
+    objectify?: boolean
+}
+
+export interface Listener {
+    emitter: EventEmitter2;
+    event: event|eventNS;
+    listener: ListenerFn;
+    off(): this;
 }
 
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
     emit(event: event | eventNS, ...values: any[]): boolean;
     emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
-    addListener(event: event | eventNS, listener: Listener): this;
-    on(event: event | eventNS, listener: Listener, options?: boolean|OnOptions): this;
-    prependListener(event: event | eventNS, listener: Listener, options?: boolean|OnOptions): this;
-    once(event: event | eventNS, listener: Listener, options?: true|OnOptions): this;
-    prependOnceListener(event: event | eventNS, listener: Listener, options?: boolean|OnOptions): this;
-    many(event: event | eventNS, timesToListen: number, listener: Listener, options?: boolean|OnOptions): this;
-    prependMany(event: event | eventNS, timesToListen: number, listener: Listener, options?: boolean|OnOptions): this;
+    addListener(event: event | eventNS, listener: ListenerFn): this;
+    on(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    prependListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    once(event: event | eventNS, listener: ListenerFn, options?: true|OnOptions): this|Listener;
+    prependOnceListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    many(event: event | eventNS, timesToListen: number, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    prependMany(event: event | eventNS, timesToListen: number, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
     onAny(listener: EventAndListener): this;
     prependAny(listener: EventAndListener): this;
-    offAny(listener: Listener): this;
-    removeListener(event: event | eventNS, listener: Listener): this;
-    off(event: event | eventNS, listener: Listener): this;
+    offAny(listener: ListenerFn): this;
+    removeListener(event: event | eventNS, listener: ListenerFn): this;
+    off(event: event | eventNS, listener: ListenerFn): this;
     removeAllListeners(event?: event | eventNS): this;
     setMaxListeners(n: number): void;
     getMaxListeners(): number;
     eventNames(): string[];
     listenerCount(event?: event | eventNS): number
-    listeners(event?: event | eventNS): Listener[]
-    listenersAny(): Listener[]
+    listeners(event?: event | eventNS): ListenerFn[]
+    listenersAny(): ListenerFn[]
     waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>
     waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>
     waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -745,16 +745,16 @@
 
   EventEmitter.prototype.event = '';
 
-  EventEmitter.prototype.once = function(event, fn) {
-    return this._once(event, fn, false);
+  EventEmitter.prototype.once = function(event, fn, options) {
+    return this._once(event, fn, false, options);
   };
 
   EventEmitter.prototype.prependOnceListener = function(event, fn, options) {
     return this._once(event, fn, true, options);
   };
 
-  EventEmitter.prototype._once = function(event, fn, prepend) {
-    this._many(event, 1, fn, prepend);
+  EventEmitter.prototype._once = function(event, fn, prepend, options) {
+    this._many(event, 1, fn, prepend, options);
     return this;
   };
 

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -586,8 +586,18 @@
     }
   }
 
-  function wrapListener(listener, options){
-      var async, promisify, nextTick;
+  function Listener(emitter, event, listener){
+    this.emitter= emitter;
+    this.event= event;
+    this.listener= listener;
+  }
+
+  Listener.prototype.off= function(){
+    this.emitter.off(this.event, this.listener);
+    return this;
+  };
+
+  function setupListener(event, listener, options){
       if (options === true) {
         promisify = true;
       } else if (options === false) {
@@ -596,9 +606,10 @@
         if (!options || typeof options !== 'object') {
           throw TypeError('options should be an object or true');
         }
-        async = options.async;
-        promisify = options.promisify;
-        nextTick = options.nextTick;
+        var async = options.async;
+        var promisify = options.promisify;
+        var nextTick = options.nextTick;
+        var objectify = options.objectify;
       }
 
       if (async || nextTick || promisify) {
@@ -633,7 +644,7 @@
         listener._origin = _origin;
       }
 
-      return listener;
+    return [listener, objectify? new Listener(this, event, listener): this];
   }
 
   function EventEmitter(conf) {
@@ -754,8 +765,7 @@
   };
 
   EventEmitter.prototype._once = function(event, fn, prepend, options) {
-    this._many(event, 1, fn, prepend, options);
-    return this;
+    return this._many(event, 1, fn, prepend, options);
   };
 
   EventEmitter.prototype.many = function(event, ttl, fn, options) {
@@ -782,9 +792,7 @@
 
     listener._origin = fn;
 
-    this._on(event, listener, prepend, options);
-
-    return self;
+    return this._on(event, listener, prepend, options);
   };
 
   EventEmitter.prototype.emit = function() {
@@ -1083,9 +1091,12 @@
     }
     this._events || init.call(this);
 
-    //if (typeof options !== 'undefined') {
+    var returnValue= this, temp;
+
     if (options !== undefined) {
-      listener = wrapListener.call(this, listener, options);
+      temp = setupListener.call(this, type, listener, options);
+      listener = temp[0];
+      returnValue = temp[1];
     }
 
     // To avoid recursion in the case that type == "newListeners"! Before
@@ -1126,7 +1137,7 @@
       }
     }
 
-    return this;
+    return returnValue;
   };
 
   EventEmitter.prototype.off = function(type, listener) {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -586,6 +586,56 @@
     }
   }
 
+  function wrapListener(listener, options){
+      var async, promisify, nextTick;
+      if (options === true) {
+        promisify = true;
+      } else if (options === false) {
+        async = true;
+      } else {
+        if (!options || typeof options !== 'object') {
+          throw TypeError('options should be an object or true');
+        }
+        async = options.async;
+        promisify = options.promisify;
+        nextTick = options.nextTick;
+      }
+
+      if (async || nextTick || promisify) {
+        var _listener = listener;
+        var _origin = listener._origin || listener;
+
+        if (nextTick && !nextTickSupported) {
+          throw Error('process.nextTick is not supported');
+        }
+
+        if (promisify === undefined) {
+          promisify = listener.constructor.name === 'AsyncFunction';
+        }
+
+        listener = function () {
+          var args = arguments;
+          var context = this;
+          var event = this.event;
+
+          return promisify ? (nextTick ? Promise.resolve() : new Promise(function (resolve) {
+            _setImmediate(resolve);
+          }).then(function () {
+            context.event = event;
+            return _listener.apply(context, args)
+          })) : (nextTick ? process.nextTick : _setImmediate)(function () {
+            context.event = event;
+            _listener.apply(context, args)
+          });
+        };
+
+        listener._async = true;
+        listener._origin = _origin;
+      }
+
+      return listener;
+  }
+
   function EventEmitter(conf) {
     this._events = {};
     this._observers= [];
@@ -1033,52 +1083,9 @@
     }
     this._events || init.call(this);
 
+    //if (typeof options !== 'undefined') {
     if (options !== undefined) {
-      var async, promisify, nextTick;
-      if (options === true) {
-        promisify = true;
-      } else if (options === false) {
-        async = true;
-      } else {
-        if (!options || typeof options !== 'object') {
-          throw TypeError('options should be an object or true');
-        }
-        async = options.async;
-        promisify = options.promisify;
-        nextTick = options.nextTick;
-      }
-
-      if (async || nextTick || promisify) {
-        var _listener = listener;
-        var _origin = listener._origin || listener;
-
-        if (nextTick && !nextTickSupported) {
-          throw Error('process.nextTick is not supported');
-        }
-
-        if (promisify === undefined) {
-          promisify = listener.constructor.name === 'AsyncFunction';
-        }
-
-        listener = function () {
-          var args = arguments;
-          var context = this;
-          var event = this.event;
-
-          return promisify ? (nextTick ? Promise.resolve() : new Promise(function (resolve) {
-            _setImmediate(resolve);
-          }).then(function () {
-            context.event = event;
-            return _listener.apply(context, args)
-          })) : (nextTick ? process.nextTick : _setImmediate)(function () {
-            context.event = event;
-            _listener.apply(context, args)
-          });
-        };
-
-        listener._async = true;
-        listener._origin = _origin;
-      }
+      listener = wrapListener.call(this, listener, options);
     }
 
     // To avoid recursion in the case that type == "newListeners"! Before

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -11,16 +11,17 @@
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
   var defaultMaxListeners = 10;
-  var supportSymbols= typeof Symbol==='function';
-  var supportReflect= typeof Reflect === 'object';
-  var ownKeys= supportSymbols? (supportReflect && typeof Reflect.ownKeys==='function'? Reflect.ownKeys : function(obj){
+  var nextTickSupported= typeof process=='object' && typeof process.nextTick=='function';
+  var symbolsSupported= typeof Symbol==='function';
+  var reflectSupported= typeof Reflect === 'object';
+  var setImmediateSupported= typeof setImmediate === 'function';
+  var _setImmediate= setImmediateSupported ? setImmediate : setTimeout;
+  var ownKeys= symbolsSupported? (reflectSupported && typeof Reflect.ownKeys==='function'? Reflect.ownKeys : function(obj){
     var arr= Object.getOwnPropertyNames(obj);
     var arr2= Object.getOwnPropertySymbols(obj);
     arr.push.apply(arr, arr2);
     return arr;
   }) : Object.keys;
-
-
 
   function init() {
     this._events = {};
@@ -698,8 +699,8 @@
     return this._once(event, fn, false);
   };
 
-  EventEmitter.prototype.prependOnceListener = function(event, fn) {
-    return this._once(event, fn, true);
+  EventEmitter.prototype.prependOnceListener = function(event, fn, options) {
+    return this._once(event, fn, true, options);
   };
 
   EventEmitter.prototype._once = function(event, fn, prepend) {
@@ -707,15 +708,15 @@
     return this;
   };
 
-  EventEmitter.prototype.many = function(event, ttl, fn) {
-    return this._many(event, ttl, fn, false);
+  EventEmitter.prototype.many = function(event, ttl, fn, options) {
+    return this._many(event, ttl, fn, false, options);
   };
 
-  EventEmitter.prototype.prependMany = function(event, ttl, fn) {
-    return this._many(event, ttl, fn, true);
+  EventEmitter.prototype.prependMany = function(event, ttl, fn, options) {
+    return this._many(event, ttl, fn, true, options);
   };
 
-  EventEmitter.prototype._many = function(event, ttl, fn, prepend) {
+  EventEmitter.prototype._many = function(event, ttl, fn, prepend, options) {
     var self = this;
 
     if (typeof fn !== 'function') {
@@ -731,7 +732,7 @@
 
     listener._origin = fn;
 
-    this._on(event, listener, prepend);
+    this._on(event, listener, prepend, options);
 
     return self;
   };
@@ -762,7 +763,7 @@
         }else{
           ns = type.slice();
           l= type.length;
-          if(supportSymbols) {
+          if(symbolsSupported) {
             for (i = 0; i < l; i++) {
               if (typeof type[i] === 'symbol') {
                 containsSymbol = true;
@@ -888,7 +889,7 @@
         }else{
           ns = type.slice();
           l= type.length;
-          if(supportSymbols) {
+          if(symbolsSupported) {
             for (i = 0; i < l; i++) {
               if (typeof type[i] === 'symbol') {
                 containsSymbol = true;
@@ -984,12 +985,12 @@
     return Promise.all(promises);
   };
 
-  EventEmitter.prototype.on = function(type, listener) {
-    return this._on(type, listener, false);
+  EventEmitter.prototype.on = function(type, listener, options) {
+    return this._on(type, listener, false, options);
   };
 
-  EventEmitter.prototype.prependListener = function(type, listener) {
-    return this._on(type, listener, true);
+  EventEmitter.prototype.prependListener = function(type, listener, options) {
+    return this._on(type, listener, true, options);
   };
 
   EventEmitter.prototype.onAny = function(fn) {
@@ -1021,7 +1022,7 @@
     return this;
   };
 
-  EventEmitter.prototype._on = function(type, listener, prepend) {
+  EventEmitter.prototype._on = function(type, listener, prepend, options) {
     if (typeof type === 'function') {
       this._onAny(type, listener);
       return this;
@@ -1031,6 +1032,54 @@
       throw new Error('on only accepts instances of Function');
     }
     this._events || init.call(this);
+
+    if (options !== undefined) {
+      var async, promisify, nextTick;
+      if (options === true) {
+        promisify = true;
+      } else if (options === false) {
+        async = true;
+      } else {
+        if (!options || typeof options !== 'object') {
+          throw TypeError('options should be an object or true');
+        }
+        async = options.async;
+        promisify = options.promisify;
+        nextTick = options.nextTick;
+      }
+
+      if (async || nextTick || promisify) {
+        var _listener = listener;
+        var _origin = listener._origin || listener;
+
+        if (nextTick && !nextTickSupported) {
+          throw Error('process.nextTick is not supported');
+        }
+
+        if (promisify === undefined) {
+          promisify = listener.constructor.name === 'AsyncFunction';
+        }
+
+        listener = function () {
+          var args = arguments;
+          var context = this;
+          var event = this.event;
+
+          return promisify ? (nextTick ? Promise.resolve() : new Promise(function (resolve) {
+            _setImmediate(resolve);
+          }).then(function () {
+            context.event = event;
+            return _listener.apply(context, args)
+          })) : (nextTick ? process.nextTick : _setImmediate)(function () {
+            context.event = event;
+            _listener.apply(context, args)
+          });
+        };
+
+        listener._async = true;
+        listener._origin = _origin;
+      }
+    }
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".
@@ -1386,7 +1435,7 @@
 
   Object.defineProperties(EventEmitter, {
     defaultMaxListeners: {
-      get: function(){
+      get: function () {
         return prototype._maxListeners;
       },
       set: function (n) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eventemitter2",
   "version": "6.3.1",
-  "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL, promises and browser support.",
+  "description": "A feature-rich Node.js event emitter implementation with namespaces, wildcards, TTL, async listeners and browser support.",
   "keywords": [
     "event",
     "events",

--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -33,8 +33,8 @@ os.cpus().forEach(function(cpu){
   }
 });
 
-console.log('Cpu:' + Object.entries(cpus).map(function([cpu, count]){
-  return [' ', count, ' x ', cpu].join('');
+console.log('CPU:' + Object.entries(cpus).map(function(data){
+  return [' ', data[1], ' x ', data[0]].join('');
 }).join('\n'));
 
 console.log('----------------------------------------------------------------');

--- a/test/simple/addListener.js
+++ b/test/simple/addListener.js
@@ -279,22 +279,80 @@ module.exports = simpleEvents({
     });
   },
 
-    '14. should support wrapping once listener to an async listener': function (done) {
-        var ee = new EventEmitter2();
-        var counter = 0;
-        var f = function (x) {
-            assert.equal(x, 123);
-            counter++;
-        };
-        ee.once('test', f, false);
-        assert.equal(ee.listenerCount(), 1);
-        ee.emit('test', 123);
-        assert.equal(counter, 0, 'the event was emitted synchronously');
-        setTimeout(function () {
-            assert.equal(counter, 1);
-            ee.off('test', f);
-            assert.equal(ee.listenerCount(), 0);
-            done();
-        }, 10);
-    }
+  '14. should support wrapping once listener to an async listener': function (done) {
+    var ee = new EventEmitter2();
+    var counter = 0;
+    var f = function (x) {
+      assert.equal(x, 123);
+      counter++;
+    };
+    ee.once('test', f, false);
+    assert.equal(ee.listenerCount(), 1);
+    ee.emit('test', 123);
+    assert.equal(counter, 0, 'the event was emitted synchronously');
+    setTimeout(function () {
+      assert.equal(counter, 1);
+      ee.off('test', f);
+      assert.equal(ee.listenerCount(), 0);
+      done();
+    }, 10);
+  },
+
+  '15. should support returning a listener object if the objectify options is set': function () {
+    var ee = new EventEmitter2();
+    var counter = 0;
+    var handler = function (x) {
+      assert.equal(x, 123);
+      counter++;
+    };
+
+    var listener= ee.on('test', handler, {
+      objectify: true
+    });
+
+    assert.equal(typeof listener, 'object');
+    assert.equal(listener.constructor.name, 'Listener');
+    assert.equal(typeof listener.off, 'function');
+    assert.equal(listener.emitter, ee);
+    assert.equal(listener.event, 'test');
+    assert.equal(listener.listener, handler);
+
+    assert.equal(counter, 0);
+
+    ee.emit('test', 123);
+    assert.equal(counter, 1);
+
+    listener.off();
+
+    ee.emit('test', 123);
+    assert.equal(counter, 1);
+  },
+
+  '16. should support returning a listener object using the `once` method if the objectify options is set': function () {
+    var ee = new EventEmitter2();
+    var counter = 0;
+    var handler = function (x) {
+      assert.equal(x, 123);
+      counter++;
+    };
+
+    var listener= ee.once('test', handler, {
+      objectify: true
+    });
+
+    assert.equal(typeof listener, 'object');
+    assert.equal(listener.constructor.name, 'Listener');
+    assert.equal(typeof listener.off, 'function');
+    assert.equal(listener.emitter, ee);
+    assert.equal(listener.event, 'test');
+    assert.equal(listener.listener._origin, handler);
+
+    assert.equal(counter, 0);
+
+    listener.off();
+
+    ee.emit('test', 123);
+
+    assert.equal(counter, 0);
+  }
 });

--- a/test/simple/addListener.js
+++ b/test/simple/addListener.js
@@ -277,5 +277,24 @@ module.exports = simpleEvents({
       assert.equal(ee.listenerCount(), 0);
       done();
     });
-  }
+  },
+
+    '14. should support wrapping once listener to an async listener': function (done) {
+        var ee = new EventEmitter2();
+        var counter = 0;
+        var f = function (x) {
+            assert.equal(x, 123);
+            counter++;
+        };
+        ee.once('test', f, false);
+        assert.equal(ee.listenerCount(), 1);
+        ee.emit('test', 123);
+        assert.equal(counter, 0, 'the event was emitted synchronously');
+        setTimeout(function () {
+            assert.equal(counter, 1);
+            ee.off('test', f);
+            assert.equal(ee.listenerCount(), 0);
+            done();
+        }, 10);
+    }
 });


### PR DESCRIPTION
Adds support of invoking listeners asynchronously using setImmediate (with fallback to setTimeout) or process.nextTick. Also supports async function wrapping (or any function that returns a promise).
There is no performance loss if this feature is not used.
Now `on`, `once`, `prependListener`, `prependOnceListener`, `many` have an optional `options` argument, with following options:
- `async?:boolean` - use setImmediate | setTimeout
- `nextTick?:boolean` - use nextTick
- `promisify?:boolean` - use setImmediate | setTimeout | nextTick and wrap into a Promise (for using with `emitAsync`). If it is undefined and the listener is an AsyncFunction it sets to true.

```javascript
var EventEmitter2= require('../lib/eventemitter2');
var emitter= new EventEmitter2();

emitter.on('event', function(){
    console.log('The event was raised! (setImmediate)');
}, {async: true});

emitter.on('event', function(){
    console.log('The event was raised! (nextTick)');
}, {nextTick: true});

emitter.emit('event');
console.log('emitted');
````
Output:
```
emitted
The event was raised! (nextTick)
The event was raised! (setImmediate)
```

```javascript
var EventEmitter2= require('../lib/eventemitter2');
var emitter= new EventEmitter2();

emitter.on('event', function(){
    console.log('The event was raised!');
    return new Promise(function(resolve){
       console.log('listener resolved');
       setTimeout(resolve, 1000);
    });
}, {promisify: true});

emitter.emitAsync('event').then(function(){
    console.log('all listeners were resolved!');
});

console.log('emitted');
```
Output:
```
emitted
The event was raised!
listener resolved
all listeners were resolved!
```
There are some shortcuts:
If the options argument is `true` it will be considered as `{promisify: true}`
If the options argument is `false` it will be considered as `{async: true}`
So:
````javascript
emitter.on('event', function(){}, {async: true});
// is equal to
emitter.on('event', function(){}, false);
// AND
emitter.on('event', function(){}, {promisify: true});
// is equal to
emitter.on('event', function(){}, true);
````
P.S. this PR depends on #252 