### PR TITLE
Release 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 For changes before version 2.2.0, please see the commit history
 
+## [6.4.0] - 2020-05-04
+
+### Added
+
+- Symbol events support for simple and wildcard emitters #201
+- `emitter.hasListeners` method #251
+- `emitter.listenTo` & `emitter.stopListening` methods for listening to an external event emitter of any kind and propagate its events through itself using optional reducers/filters
+- async listeners for invoking handlers using setImmediate|setTimeout|nextTick (see `async`, `promisify` and `nextTicks` options for subscription methods)
+- Ability for subscription methods to return a listener object to simplify subscription management (see the `objectify` option)
+- micro optimizations for performance reasons
+
+### Fixed
+
+- Event name/reference normalization for the `this.event` property #162
+- Bug with data arguments for `Any` listeners #254
+- `emitter.eventNames` now supports wildcard emitters #214
+
 ## [6.3.0] - 2020-03-28
 
 ### Added
 - emitter.getMaxListeners() & EventEmitter2.defaultMaxListeners() @DigitalBrainJS
-- EventEmitter2.once for feature pairity with EventEmitter.once @DigitalBrainJS
+- EventEmitter2.once for feature parity with EventEmitter.once @DigitalBrainJS
 
 ## [6.2.1] - 2020-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,18 @@ For changes before version 2.2.0, please see the commit history
 
 ### Added
 
-- Symbol events support for simple and wildcard emitters #201
-- `emitter.hasListeners` method #251
-- `emitter.listenTo` & `emitter.stopListening` methods for listening to an external event emitter of any kind and propagate its events through itself using optional reducers/filters
-- async listeners for invoking handlers using setImmediate|setTimeout|nextTick (see `async`, `promisify` and `nextTicks` options for subscription methods)
-- Ability for subscription methods to return a listener object to simplify subscription management (see the `objectify` option)
-- micro optimizations for performance reasons
+- Symbol events support for simple and wildcard emitters #201 @DigitalBrainJS
+- `emitter.hasListeners` method #251 @DigitalBrainJS
+- `emitter.listenTo` & `emitter.stopListeningTo` methods for listening to an external event emitter of any kind and propagate its events through itself using optional reducers/filters @DigitalBrainJS
+- async listeners for invoking handlers using setImmediate|setTimeout|nextTick (see `async`, `promisify` and `nextTicks` options for subscription methods) @DigitalBrainJS
+- Ability for subscription methods to return a listener object to simplify subscription management (see the `objectify` option) @DigitalBrainJS
+- micro optimizations for performance reasons @DigitalBrainJS
 
 ### Fixed
 
-- Event name/reference normalization for the `this.event` property #162
-- Bug with data arguments for `Any` listeners #254
-- `emitter.eventNames` now supports wildcard emitters #214
+- Event name/reference normalization for the `this.event` property #162 @DigitalBrainJS
+- Bug with data arguments for `Any` listeners #254 @DigitalBrainJS
+- `emitter.eventNames` now supports wildcard emitters #214 @DigitalBrainJS
 
 ## [6.3.0] - 2020-03-28
 

--- a/README.md
+++ b/README.md
@@ -6,20 +6,26 @@
 
 # SYNOPSIS
 
-EventEmitter2 is an implementation of the EventEmitter module found in Node.js. In addition to having a better benchmark performance than EventEmitter and being browser-compatible, it also extends the interface of EventEmitter with additional non-breaking features.
+EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
+In addition to having a better benchmark performance than EventEmitter and being browser-compatible, 
+it also extends the interface of EventEmitter with many additional non-breaking features.
+
+If you like this project please show your support with a [GitHub :star:](https://github.com/EventEmitter2/EventEmitter2/stargazers)!
 
 # DESCRIPTION
 
 ### FEATURES
+ - ES5 compatible UMD module, that supports node.js, browser and workers of any kind
  - Namespaces/Wildcards
+ - [Any](#emitteronanylistener) listeners
  - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent--eventns-timestolisten-listener-options)
  - [Async listeners](#emitteronevent-listener-options-objectboolean) (using setImmediate|setTimeout|nextTick) with promise|async function support
  - The [emitAsync](#emitteremitasyncevent--eventns-arg1-arg2-) method to return the results of the listeners via Promise.all
- - Subscription methods ([on](#emitteronevent-listener-options-objectboolean), once, many, ...) can return a 
+ - Subscription methods ([on](#emitteronevent-listener-options-objectboolean), [once](#emitterprependoncelistenerevent--eventns-listener-options), [many](#emittermanyevent--eventns-timestolisten-listener-options), ...) can return a 
  [listener](#listener) object that makes it easy to remove the subscription when needed - just call the listener.off() method.
  - Feature-rich [waitFor](#emitterwaitforevent--eventns-options) method to wait for events using promises
  - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event-event--eventns-boolean) methods
- for listening to an external event emitter and propagate its events through itself using optional reducers/filters 
+ for listening to an external event emitter of any kind and propagate its events through itself using optional reducers/filters 
  - Extended version of the [events.once](#eventemitter2onceemitter-event--eventns-options) method from the [node events API](https://nodejs.org/api/events.html#events_events_once_emitter_name)
  - Browser & Workers environment compatibility
  - Demonstrates good performance in benchmarks

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ server.many(['foo', 'bar', 'bazz'], 4, function() {
 $ npm install eventemitter2
 ```
 
-Or you can use unpkg.com CDN to import this [module](https://unpkg.com/eventemitter2) directly from the browser 
+Or you can use unpkg.com CDN to import this [module](https://unpkg.com/eventemitter2) as a script directly from the browser 
 
 # API
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ server.many(['foo', 'bar', 'bazz'], 4, function() {
 $ npm install eventemitter2
 ```
 
+Or you can use unpkg.com CDN to import this [module](https://unpkg.com/eventemitter2) directly from the browser 
+
 # API
 
 ### Types definition

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you like this project please show your support with a [GitHub :star:](https:/
  - Subscription methods ([on](#emitteronevent-listener-options-objectboolean), [once](#emitterprependoncelistenerevent--eventns-listener-options), [many](#emittermanyevent--eventns-timestolisten-listener-options), ...) can return a 
  [listener](#listener) object that makes it easy to remove the subscription when needed - just call the listener.off() method.
  - Feature-rich [waitFor](#emitterwaitforevent--eventns-options) method to wait for events using promises
- - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event-event--eventns-boolean) methods
+ - [listenTo](#listentotargetemitter-events-objectevent--eventns-function-options) & [stopListeningTo](#stoplisteningtotarget-object-event-event--eventns-boolean) methods
  for listening to an external event emitter of any kind and propagate its events through itself using optional reducers/filters 
  - Extended version of the [events.once](#eventemitter2onceemitter-event--eventns-options) method from the [node events API](https://nodejs.org/api/events.html#events_events_once_emitter_name)
  - Browser & Workers environment compatibility
@@ -77,15 +77,15 @@ var emitter = new EventEmitter2({
  - Getting the actual event that fired.
 
 ```javascript
-server.on('foo.*', function() {
-  console.log(this.event); 
+emitter.on('foo.*', function(value1, value2) {
+  console.log(this.event, value1, value2);
 });
 
-server.emit('foo.bar'); // foo.bar
-server.emit(['foo', 'bar']); // foo.bar
+emitter.emit('foo.bar', 1, 2); // 'foo.bar' 1 2
+emitter.emit(['foo', 'bar'], 3, 4); // 'foo.bar' 3 4
 
-server.emit(Symbol()); // Symbol()
-server.emit(['foo', Symbol()]); // ['foo', Symbol())
+emitter.emit(Symbol(), 5, 6); // Symbol() 5 6
+emitter.emit(['foo', Symbol(), 7, 8]); // ['foo', Symbol()] 7 8
 ```
 **Note**: Generally this.event is normalized to a string ('event', 'event.test'),
 except the cases when event is a symbol or namespace contains a symbol. 
@@ -178,7 +178,7 @@ Or you can use unpkg.com CDN to import this [module](https://unpkg.com/eventemit
 
 - [listenTo(target: GeneralEventEmitter, events: Object<event | eventNS, Function>, options?: ListenToOptions): this](#listentotargetemitter-events-objectevent--eventns-function-options)
 
-- [stopListening(target?: GeneralEventEmitter, event?: event | eventNS): Boolean](#stoplisteningtarget-object-event-event--eventns-boolean)
+- [stopListeningTo(target?: GeneralEventEmitter, event?: event | eventNS): Boolean](#stoplisteningtarget-object-event-event--eventns-boolean)
 
 ### static:
 
@@ -666,11 +666,11 @@ emitter.on('localConnection', function(socket){
 });
 
 setTimeout(function(){
-    emitter.stopListening(server);
+    emitter.stopListeningTo(server);
 }, 30000);
 ````
 
-### stopListening(target?: Object, event: event | eventNS): Boolean
+### stopListeningTo(target?: Object, event: event | eventNS): Boolean
 
 Stops listening the targets. Returns true if some listener was removed.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.com/EventEmitter2/EventEmitter2.svg?branch=master)](https://travis-ci.com/DigitalBrainJS/define-accessor2)
-[![Coverage Status](https://coveralls.io/repos/github/EventEmitter2/EventEmitter2/badge.svg?branch=master)](https://coveralls.io/github/DigitalBrainJS/define-accessor2?branch=master)
+[![Build Status](https://travis-ci.com/EventEmitter2/EventEmitter2.svg?branch=master)](https://travis-ci.com/EventEmitter2/EventEmitter2)
+[![Coverage Status](https://coveralls.io/repos/github/EventEmitter2/EventEmitter2/badge.svg?branch=master)](https://coveralls.io/github/EventEmitter2/EventEmitter2?branch=master)
 [![NPM version](https://badge.fury.io/js/eventemitter2.svg)](http://badge.fury.io/js/eventemitter2)
 [![Dependency Status](https://img.shields.io/david/asyncly/eventemitter2.svg)](https://david-dm.org/asyncly/eventemitter2)
 [![npm](https://img.shields.io/npm/dm/eventemitter2.svg?maxAge=2592000)]()
@@ -12,62 +12,54 @@ EventEmitter2 is an implementation of the EventEmitter module found in Node.js. 
 
 ### FEATURES
  - Namespaces/Wildcards
- - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent-timestolisten-listener)
- - The [emitAsync](#emitteremitasyncevent-arg1-arg2-) method to return the results of the listeners via Promise.all
- - Feature-rich [waitFor](#emitterwaitforevent-options) method to wait for events using promises
- - Extended version of the [events.once](#eventemitter2onceemitter-name-options) method from the [node events API](https://nodejs.org/api/events.html#events_events_once_emitter_name)
+ - Times To Listen (TTL), extends the `once` concept with [`many`](#emittermanyevent--eventns-timestolisten-listener)
+ - The [emitAsync](#emitteremitasyncevent--eventns-arg1-arg2-) method to return the results of the listeners via Promise.all
+ - Feature-rich [waitFor](#emitterwaitforevent--eventns-options) method to wait for events using promises
+ - [listenTo](#listentotargetemitter-events-event--eventns-options) & [stopListening](#stoplisteningtarget-object-event-event--eventns-boolean) methods
+ for listening to an external event emitter and propagate its events through itself using optional reducers/filters 
+ - Extended version of the [events.once](#eventemitter2onceemitter-event--eventns-options) method from the [node events API](https://nodejs.org/api/events.html#events_events_once_emitter_name)
  - Browser & Workers environment compatibility
  - Demonstrates good performance in benchmarks
 
 ```
-EventEmitterHeatUp x 3,728,965 ops/sec \302\2610.68% (60 runs sampled)
-EventEmitter x 2,822,904 ops/sec \302\2610.74% (63 runs sampled)
-EventEmitter2 x 7,251,227 ops/sec \302\2610.55% (58 runs sampled)
-EventEmitter2 (wild) x 3,220,268 ops/sec \302\2610.44% (65 runs sampled)
+Platform: win32, x64, 15267MB
+Node version: v13.11.0
+Cpu: 4 x AMD Ryzen 3 2200U with Radeon Vega Mobile Gfx @ 2495MHz
+----------------------------------------------------------------
+EventEmitterHeatUp x 3,017,814 ops/sec ±3.37% (68 runs sampled)
+EventEmitter x 3,357,197 ops/sec ±4.66% (62 runs sampled)
+EventEmitter2 x 11,378,225 ops/sec ±3.99% (62 runs sampled)
+EventEmitter2 (wild) x 4,799,373 ops/sec ±4.01% (66 runs sampled)
+EventEmitter3 x 10,007,114 ops/sec ±3.94% (69 runs sampled)
 Fastest is EventEmitter2
 ```
 
 ### Differences (Non-breaking, compatible with existing EventEmitter)
 
- - The EventEmitter2 constructor takes an optional configuration object.
- 
+ - The EventEmitter2 constructor takes an optional configuration object with the following default values:
 ```javascript
-var EventEmitter2 = require('eventemitter2').EventEmitter2;
-var server = new EventEmitter2({
+var EventEmitter2 = require('eventemitter2');
+var emitter = new EventEmitter2({
 
-  //
-  // set this to `true` to use wildcards. It defaults to `false`.
-  //
-  wildcard: true,
+  // set this to `true` to use wildcards
+  wildcard: false,
 
-  //
-  // the delimiter used to segment namespaces, defaults to `.`.
-  //
-  delimiter: '::', 
-  
-  //
-  // set this to `true` if you want to emit the newListener event. The default value is `false`.
-  //
+  // the delimiter used to segment namespaces
+  delimiter: '.', 
+
+  // set this to `true` if you want to emit the newListener event
   newListener: false, 
-  
-  //
-  // set this to `true` if you want to emit the removeListener event. The default value is `false`.
-  //
+
+  // set this to `true` if you want to emit the removeListener event
   removeListener: false, 
 
-  //
-  // the maximum amount of listeners that can be assigned to an event, default 10.
-  //
-  maxListeners: 20,
-  
-  //
-  // show event name in memory leak message when more than maximum amount of listeners is assigned, default false
-  //
+  // the maximum amount of listeners that can be assigned to an event
+  maxListeners: 10,
+
+  // show event name in memory leak message when more than maximum amount of listeners is assigned
   verboseMemoryLeak: false,
 
-  //
   // disable throwing uncaughtException if an error event is emitted and it has no listeners
-  //
   ignoreErrors: false
 });
 ```
@@ -75,10 +67,19 @@ var server = new EventEmitter2({
  - Getting the actual event that fired.
 
 ```javascript
-server.on('foo.*', function(value1, value2) {
-  console.log(this.event, value1, value2);
+server.on('foo.*', function() {
+  console.log(this.event); 
 });
+
+server.emit('foo.bar'); // foo.bar
+server.emit(['foo', 'bar']); // foo.bar
+
+server.emit(Symbol()); // Symbol()
+server.emit(['foo', Symbol()]); // ['foo', Symbol())
 ```
+**Note**: Generally this.event is normalized to a string ('event', 'event.test'),
+except the cases when event is a symbol or namespace contains a symbol. 
+In these cases this.event remains as is (symbol and array). 
 
  - Fire an event N times and then remove it, an extension of the `once` concept.
 
@@ -99,10 +100,82 @@ server.many(['foo', 'bar', 'bazz'], 4, function() {
 # Installing
 
 ```console
-$ npm install --save eventemitter2
+$ npm install eventemitter2
 ```
 
 # API
+
+### Types definition
+- `Event`: string | symbol
+- `EventNS`: string | Event []
+
+## Class EventEmitter2
+
+### instance:
+- [emit(event: event | eventNS, ...values: any[]): boolean](#emitteremitevent--eventns-arg1-arg2-);
+
+- [emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>](#emitteremitasyncevent--eventns-arg1-arg2-)
+
+- [addListener(event: event | eventNS, listener: Listener): this](#emitteraddlistenerevent-listener)
+
+- [on(event: event | eventNS, listener: Listener): this](#emitteraddlistenerevent-listener)
+
+- [prependListener(event: event | eventNS, listener: Listener): this](#emitterprependlistenerevent-listener)
+
+- [once(event: event | eventNS, listener: Listener): this](#emitteronceevent--eventns-listener)
+
+- [prependOnceListener(event: event | eventNS, listener: Listener): this](#emitterprependoncelistenerevent--eventns-listener)
+
+- [many(event: event | eventNS, timesToListen: number, listener: Listener): this](#emittermanyevent--eventns-timestolisten-listener)
+
+- [prependMany(event: event | eventNS, timesToListen: number, listener: Listener): this](#emitterprependanylistener)
+
+- [onAny(listener: EventAndListener): this](#emitteronanylistener)
+
+- [prependAny(listener: EventAndListener): this](#emitterprependanylistener)
+
+- [offAny(listener: Listener): this](#emitteroffanylistener)
+
+- [removeListener(event: event | eventNS, listener: Listener): this](#emitterremovelistenerevent--eventns-listener)
+
+- [off(event: event | eventNS, listener: Listener): this](#emitteroffevent--eventns-listener)
+
+- [removeAllListeners(event?: event | eventNS): this](#emitterremovealllistenersevent--eventns)
+
+- [setMaxListeners(n: number): void](#emittersetmaxlistenersn)
+
+- [getMaxListeners(): number](#emittergetmaxlisteners)
+
+- [eventNames(nsAsArray?: boolean): string[]](#emittereventnamesnsasarray)
+
+- [listeners(event: event | eventNS): Listener[]](#emitterlistenersevent--eventns)
+
+- [listenersAny(): Listener[]](#emitterlistenersany)
+
+- [waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>](#emitterwaitforevent--eventns-timeout)
+
+- [waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>](#emitterwaitforevent--eventns-filter)
+
+- [waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>](#emitterwaitforevent--eventns-options)
+
+- [listenTo(target: GeneralEventEmitter, event: event | eventNS, options?: ListenToOptions): this](#listentotargetemitter-events-event--eventns-options)
+
+- [listenTo(target: GeneralEventEmitter, events: (event | eventNS)[], options?: ListenToOptions): this](#listentotargetemitter-events-event--eventns-options)
+
+- [listenTo(target: GeneralEventEmitter, events: Object<event | eventNS, Function>, options?: ListenToOptions): this](#listentotargetemitter-events-objectevent--eventns-function-options)
+
+- [stopListening(target?: GeneralEventEmitter, event?: event | eventNS): Boolean](#stoplisteningtarget-object-event-event--eventns-boolean)
+
+- [hasListeners(event?: event | eventNS): Boolean](#haslistenersevent--eventnsstringboolean)
+
+### static:
+
+- [static once(emitter: EventEmitter2, event: string | symbol, options?: OnceOptions): CancelablePromise<any[]>](#eventemitter2onceemitter-event--eventns-options)
+
+- [static defaultMaxListeners: number](#eventemitter2defaultmaxlisteners)
+
+The `event` argument specified in the API declaration can be a string or symbol for a simple event emitter
+and a string|symbol|Array(string|symbol) in a case of a wildcard emitter; 
 
 When an `EventEmitter` instance experiences an error, the typical action is
 to emit an `error` event. Error events are treated as a special case.
@@ -129,8 +202,11 @@ If either of the above described events were passed to the `on` method,
 subsequent emits such as the following would be observed...
 
 ```javascript
+emitter.emit(Symbol());
+emitter.emit('foo');
 emitter.emit('foo.bazz');
 emitter.emit(['foo', 'bar']);
+emitter.emit(['foo', Symbol()]);
 ```
 
 **NOTE:** An event name may use more than one wildcard. For example, 
@@ -144,6 +220,7 @@ A double wildcard (the string `**`) matches any number of levels (zero or more) 
 emitter.emit('foo');
 emitter.emit('foo.bar');
 emitter.emit('foo.bar.baz');
+emitter.emit(['foo', Symbol(), 'baz');
 ````
 
 On the other hand, if the single-wildcard event name was passed to the on method, the callback would only observe the second of these events.
@@ -207,7 +284,7 @@ server.offAny(function(value) {
 });
 ```
 
-#### emitter.once(event, listener)
+#### emitter.once(event | eventNS, listener)
 
 Adds a **one time** listener for the event. The listener is invoked 
 only the first time the event is fired, after which it is removed.
@@ -218,7 +295,7 @@ server.once('get', function (value) {
 });
 ```
 
-#### emitter.prependOnceListener(event, listener)
+#### emitter.prependOnceListener(event | eventNS, listener)
 
 Adds a **one time** listener for the event. The listener is invoked 
 only the first time the event is fired, after which it is removed.
@@ -230,7 +307,7 @@ server.prependOnceListener('get', function (value) {
 });
 ```
 
-### emitter.many(event, timesToListen, listener)
+### emitter.many(event | eventNS, timesToListen, listener)
 
 Adds a listener that will execute **n times** for the event before being
 removed. The listener is invoked only the first **n times** the event is 
@@ -242,7 +319,7 @@ server.many('get', 4, function (value) {
 });
 ```
 
-### emitter.prependMany(event, timesToListen, listener)
+### emitter.prependMany(event | eventNS, timesToListen, listener)
 
 Adds a listener that will execute **n times** for the event before being
 removed. The listener is invoked only the first **n times** the event is 
@@ -257,8 +334,8 @@ server.many('get', 4, function (value) {
 
 
 
-### emitter.removeListener(event, listener)
-### emitter.off(event, listener)
+### emitter.removeListener(event | eventNS, listener)
+### emitter.off(event | eventNS, listener)
 
 Remove a listener from the listener array for the specified event. 
 **Caution**: Calling this method changes the array indices in the listener array behind the listener.
@@ -273,7 +350,7 @@ server.removeListener('get', callback);
 ```
 
 
-### emitter.removeAllListeners([event])
+### emitter.removeAllListeners([event | eventNS])
 
 Removes all listeners, or those of the specified event.
 
@@ -291,7 +368,7 @@ that to be increased. Set to zero for unlimited.
 Returns the current max listener value for the EventEmitter which is either set by emitter.setMaxListeners(n) or defaults to EventEmitter2.defaultMaxListeners
 
 
-### emitter.listeners(event)
+### emitter.listeners(event | eventNS)
 
 Returns an array of listeners for the specified event. This array can be 
 manipulated, e.g. to remove listeners.
@@ -315,12 +392,11 @@ server.onAny(function(value) {
 console.log(server.listenersAny()[0]); // [ [Function] ]
 ```
 
-### emitter.emit(event, [arg1], [arg2], [...])
-
+### emitter.emit(event | eventNS, [arg1], [arg2], [...])
 Execute each of the listeners that may be listening for the specified event 
 name in order with the list of arguments.
 
-### emitter.emitAsync(event, [arg1], [arg2], [...])
+### emitter.emitAsync(event | eventNS, [arg1], [arg2], [...])
 
 Return the results of the listeners via [Promise.all](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise/all).
 Only this method doesn't work [IE](http://caniuse.com/#search=promise).
@@ -354,9 +430,9 @@ emitter.emitAsync('get',0)
 });
 ```
 
-### emitter.waitFor(event, [options])
-### emitter.waitFor(event, [timeout])
-### emitter.waitFor(event, [filter])
+### emitter.waitFor(event | eventNS, [options])
+### emitter.waitFor(event | eventNS, [timeout])
+### emitter.waitFor(event | eventNS, [filter])
 
 Returns a thenable object (promise interface) that resolves when a specific event occurs
 
@@ -406,19 +482,37 @@ emitter.waitFor('event', {
 
 emitter.emit('event', new Error('custom error')); // reject the promise
 ````
-### emitter.eventNames()
+### emitter.eventNames(nsAsArray)
 
 Returns an array listing the events for which the emitter has registered listeners. The values in the array will be strings.
-
 ```javascript
+var emitter= new EventEmitter2();
 emitter.on('foo', () => {});
 emitter.on('bar', () => {});
 
 console.log(emitter.eventNames());
 // Prints: [ 'foo', 'bar' ]
 ```
+In wildcard mode this method returns namespaces as strings:
+````javascript
+var emitter= new EventEmitter2({
+    wildcard: true
+});
+emitter.on('a.b.c', function(){});
+emitter.on(['z', 'x', 'c'], function(){});
+console.log(emitter.eventNames()) // [ 'z.x.c', 'a.b.c' ]
+````
+If some namespace contains a Symbol member or the `nsAsArray` option is set the method will return namespace as an array of its members;
+````javascript
+var emitter= new EventEmitter2({
+    wildcard: true
+});
+emitter.on('a.b.c', function(){});
+emitter.on(['z', 'x', Symbol()], function(){});
+console.log(emitter.eventNames()) // [ [ 'z', 'x', Symbol() ], 'a.b.c' ]
+````
 
-### EventEmitter2.once(emitter, name, [options])
+### EventEmitter2.once(emitter, event | eventNS, [options])
 Creates a cancellable Promise that is fulfilled when the EventEmitter emits the given event or that is rejected
 when the EventEmitter emits 'error'. 
 The Promise will resolve with an array of all the arguments emitted to the given event.
@@ -492,8 +586,77 @@ promise.cancel();
 emitter.emit('event', 'never handled');
 ````
 
+### listenTo(targetEmitter, events: event | eventNS, options?)
 
-### emitter.listeners(eventName)
+### listenTo(targetEmitter, events: (event | eventNS)[], options?)
+
+### listenTo(targetEmitter, events: Object<event | eventNS, Function>, options?)
+
+Listens to the events emitted by an external emitter and propagate them through itself.
+The target object could be of any type that implements methods for subscribing and unsubscribing to its events. 
+By default this method attempts to use `addListener`/`removeListener`, `on`/`off` and `addEventListener`/`removeEventListener` pairs,
+but you able to define own hooks `on(event, handler)` and `off(event, handler)` in the options object to use
+custom subscription API. In these hooks `this` refers to the target object.
+
+The options object has the following interface:
+- `on(event, handler): void`
+- `off(event, handler): void`
+- `reducer: (Function) | (Object<Function>): Boolean`
+
+In case you selected the `newListener` and `removeListener` options when creating the emitter, 
+the subscription to the events of the target object will be conditional, 
+depending on whether there are listeners in the emitter that could listen them.
+
+````javascript
+var EventEmitter2 = require('EventEmitter2');
+var http = require('http');
+
+var server = http.createServer(function(request, response){
+    console.log(request.url);
+    response.end('Hello Node.js Server!')
+}).listen(3000);
+
+server.on('connection', function(req, socket, head){
+   console.log('connect');
+});
+
+// activate the ability to attach listeners on demand 
+var emitter= new EventEmitter2({
+    newListener: true,
+    removeListener: true
+});
+
+emitter.listenTo(server, {
+    'connection': 'localConnection',
+    'close': 'close'
+}, {
+    reducers: {
+        connection: function(event){
+            console.log('event name:' + event.name); //'localConnection'
+            console.log('original event name:' + event.original); //'connection'
+            return event.data[0].remoteAddress==='::1';
+        }
+    }
+});
+
+emitter.on('localConnection', function(socket){
+   console.log('local connection', socket.remoteAddress);
+});
+
+setTimeout(function(){
+    emitter.stopListening(server);
+}, 30000);
+````
+
+### stopListening(target?: Object, event: event | eventNS): Boolean
+
+Stops listening the targets. Returns true if some listener was removed.
+
+### hasListeners(event | eventNS?:String):Boolean
+
+Checks whether emitter has any listeners.
+
+### emitter.listeners(event | eventNS)
 
 Returns the array of listeners for the event named eventName.
 

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -38,7 +38,7 @@ export interface ConstructorOptions {
      */
     ignoreErrors?: boolean
 }
-export interface Listener {
+export interface ListenerFn {
     (...values: any[]): void;
 }
 export interface EventAndListener {
@@ -100,29 +100,43 @@ export interface GeneralEventEmitter{
     removeEventListener: Function
 }
 
+export interface OnOptions {
+    async?: boolean,
+    promisify?: boolean,
+    nextTick?: boolean,
+    objectify?: boolean
+}
+
+export interface Listener {
+    emitter: EventEmitter2;
+    event: event|eventNS;
+    listener: ListenerFn;
+    off(): this;
+}
+
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
     emit(event: event | eventNS, ...values: any[]): boolean;
     emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
-    addListener(event: event | eventNS, listener: Listener): this;
-    on(event: event | eventNS, listener: Listener): this;
-    prependListener(event: event | eventNS, listener: Listener): this;
-    once(event: event | eventNS, listener: Listener): this;
-    prependOnceListener(event: event | eventNS, listener: Listener): this;
-    many(event: event | eventNS, timesToListen: number, listener: Listener): this;
-    prependMany(event: event | eventNS, timesToListen: number, listener: Listener): this;
+    addListener(event: event | eventNS, listener: ListenerFn): this|Listener;
+    on(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    prependListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    once(event: event | eventNS, listener: ListenerFn, options?: true|OnOptions): this|Listener;
+    prependOnceListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    many(event: event | eventNS, timesToListen: number, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
+    prependMany(event: event | eventNS, timesToListen: number, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
     onAny(listener: EventAndListener): this;
     prependAny(listener: EventAndListener): this;
-    offAny(listener: Listener): this;
-    removeListener(event: event | eventNS, listener: Listener): this;
-    off(event: event | eventNS, listener: Listener): this;
+    offAny(listener: ListenerFn): this;
+    removeListener(event: event | eventNS, listener: ListenerFn): this;
+    off(event: event | eventNS, listener: ListenerFn): this;
     removeAllListeners(event?: event | eventNS): this;
     setMaxListeners(n: number): void;
     getMaxListeners(): number;
     eventNames(nsAsArray?: boolean): (event|eventNS)[];
     listenerCount(event?: event | eventNS): number
-    listeners(event?: event | eventNS): Listener[]
-    listenersAny(): Listener[]
+    listeners(event?: event | eventNS): ListenerFn[]
+    listenersAny(): ListenerFn[]
     waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>
     waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>
     waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -1,4 +1,6 @@
-export type eventNS = string[];
+export type event = (symbol|string);
+export type eventNS = string|event[];
+
 export interface ConstructorOptions {
     /**
      * @default false
@@ -87,31 +89,48 @@ export interface OnceOptions {
     overload: boolean
 }
 
+export interface ListenToOptions {
+    on?: { (event: event | eventNS, handler: Function): void },
+    off?: { (event: event | eventNS, handler: Function): void },
+    reducers: Function | Object
+}
+
+export interface GeneralEventEmitter{
+    addEventListener: Function,
+    removeEventListener: Function
+}
+
 export declare class EventEmitter2 {
     constructor(options?: ConstructorOptions)
-    emit(event: string | string[], ...values: any[]): boolean;
-    emitAsync(event: string | string[], ...values: any[]): Promise<any[]>;
-    addListener(event: string, listener: Listener): this;
-    on(event: string | string[], listener: Listener): this;
-    prependListener(event: string | string[], listener: Listener): this;
-    once(event: string | string[], listener: Listener): this;
-    prependOnceListener(event: string | string[], listener: Listener): this;
-    many(event: string | string[], timesToListen: number, listener: Listener): this;
-    prependMany(event: string | string[], timesToListen: number, listener: Listener): this;
+    emit(event: event | eventNS, ...values: any[]): boolean;
+    emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
+    addListener(event: event | eventNS, listener: Listener): this;
+    on(event: event | eventNS, listener: Listener): this;
+    prependListener(event: event | eventNS, listener: Listener): this;
+    once(event: event | eventNS, listener: Listener): this;
+    prependOnceListener(event: event | eventNS, listener: Listener): this;
+    many(event: event | eventNS, timesToListen: number, listener: Listener): this;
+    prependMany(event: event | eventNS, timesToListen: number, listener: Listener): this;
     onAny(listener: EventAndListener): this;
     prependAny(listener: EventAndListener): this;
     offAny(listener: Listener): this;
-    removeListener(event: string | string[], listener: Listener): this;
-    off(event: string, listener: Listener): this;
-    removeAllListeners(event?: string | eventNS): this;
+    removeListener(event: event | eventNS, listener: Listener): this;
+    off(event: event | eventNS, listener: Listener): this;
+    removeAllListeners(event?: event | eventNS): this;
     setMaxListeners(n: number): void;
     getMaxListeners(): number;
-    eventNames(): string[];
-    listeners(event: string | string[]): Listener[]
-    listenersAny(): Listener[] // TODO: not in documentation by Willian
-    waitFor(event: string, timeout?: number): CancelablePromise<any[]>
-    waitFor(event: string, filter?: WaitForFilter): CancelablePromise<any[]>
-    waitFor(event: string, options?: WaitForOptions): CancelablePromise<any[]>
-    static once(emitter: EventEmitter2, event: string | symbol, options?: OnceOptions): CancelablePromise<any[]>
+    eventNames(nsAsArray?: boolean): (event|eventNS)[];
+    listenerCount(event?: event | eventNS): number
+    listeners(event?: event | eventNS): Listener[]
+    listenersAny(): Listener[]
+    waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>
+    waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>
+    waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>
+    listenTo(target: GeneralEventEmitter, events: event | eventNS, options?: ListenToOptions): this;
+    listenTo(target: GeneralEventEmitter, events: event[], options?: ListenToOptions): this;
+    listenTo(target: GeneralEventEmitter, events: Object, options?: ListenToOptions): this;
+    stopListening(target?: GeneralEventEmitter, event?: event | eventNS): Boolean;
+    hasListeners(event?: String): Boolean
+    static once(emitter: EventEmitter2, event: event | eventNS, options?: OnceOptions): CancelablePromise<any[]>;
     static defaultMaxListeners: number;
 }

--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -143,7 +143,7 @@ export declare class EventEmitter2 {
     listenTo(target: GeneralEventEmitter, events: event | eventNS, options?: ListenToOptions): this;
     listenTo(target: GeneralEventEmitter, events: event[], options?: ListenToOptions): this;
     listenTo(target: GeneralEventEmitter, events: Object, options?: ListenToOptions): this;
-    stopListening(target?: GeneralEventEmitter, event?: event | eventNS): Boolean;
+    stopListeningTo(target?: GeneralEventEmitter, event?: event | eventNS): Boolean;
     hasListeners(event?: String): Boolean
     static once(emitter: EventEmitter2, event: event | eventNS, options?: OnceOptions): CancelablePromise<any[]>;
     static defaultMaxListeners: number;

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -604,23 +604,22 @@
   }
 
   function recursivelyGarbageCollect(root) {
-    if (!root) {
-      return;
-    }
     var keys = ownKeys(root);
     var i= keys.length;
-    var obj, key;
+    var obj, key, flag;
     while(i-->0){
       key = keys[i];
       obj = root[key];
-      if (obj && obj.constructor === Object) {
-        if (ownKeys(obj).length) {
-          recursivelyGarbageCollect(obj);
-        } else {
-          delete root[key];
-        }
+
+      if(obj){
+          flag= true;
+          if(key !== '_listeners' && !recursivelyGarbageCollect(obj)){
+             delete root[key];
+          }
       }
     }
+
+    return flag;
   }
 
   function Listener(emitter, event, listener){
@@ -1253,7 +1252,7 @@
       }
     }
 
-    recursivelyGarbageCollect(this.listenerTree);
+    this.listenerTree && recursivelyGarbageCollect(this.listenerTree);
 
     return this;
   };
@@ -1297,6 +1296,7 @@
         var leaf = leafs[iLeaf];
         leaf._listeners = null;
       }
+      this.listenerTree && recursivelyGarbageCollect(this.listenerTree);
     } else if (this._events) {
       this._events[type] = null;
     }

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -18,8 +18,7 @@
   var _setImmediate= setImmediateSupported ? setImmediate : setTimeout;
   var ownKeys= symbolsSupported? (reflectSupported && typeof Reflect.ownKeys==='function'? Reflect.ownKeys : function(obj){
     var arr= Object.getOwnPropertyNames(obj);
-    var arr2= Object.getOwnPropertySymbols(obj);
-    arr.push.apply(arr, arr2);
+    arr.push.apply(arr, Object.getOwnPropertySymbols(obj));
     return arr;
   }) : Object.keys;
 

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -613,7 +613,7 @@
     while(i-->0){
       key = keys[i];
       obj = root[key];
-      if (typeof obj === 'object' && obj.constructor === Object) {
+      if (obj && obj.constructor === Object) {
         if (ownKeys(obj).length) {
           recursivelyGarbageCollect(obj);
         } else {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -742,7 +742,7 @@
     return this;
   };
 
-  EventEmitter.prototype.stopListening = function (target, event) {
+  EventEmitter.prototype.stopListeningTo = function (target, event) {
     var observers = this._observers;
     var i = observers.length;
     var observer;

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -11,6 +11,16 @@
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
   var defaultMaxListeners = 10;
+  var supportSymbols= typeof Symbol==='function';
+  var supportReflect= typeof Reflect === 'object';
+  var ownKeys= supportSymbols? (supportReflect && typeof Reflect.ownKeys==='function'? Reflect.ownKeys : function(obj){
+    var arr= Object.getOwnPropertyNames(obj);
+    var arr2= Object.getOwnPropertySymbols(obj);
+    arr.push.apply(arr, arr2);
+    return arr;
+  }) : Object.keys;
+
+
 
   function init() {
     this._events = {};
@@ -85,10 +95,168 @@
     }
   };
 
+  function toObject(keys, values) {
+    var obj = {};
+    var key;
+    var len = keys.length;
+    var valuesCount = values ? value.length : 0;
+    for (var i = 0; i < len; i++) {
+      key = keys[i];
+      obj[key] = i < valuesCount ? values[i] : undefined;
+    }
+    return obj;
+  }
+
+  function TargetObserver(emitter, target, options) {
+    this._emitter = emitter;
+    this._target = target;
+    this._listeners = {};
+    this._listenersCount = 0;
+
+    var on, off;
+
+    if (options.on || options.off) {
+      on = options.on;
+      off = options.off;
+    }
+
+    if (target.addEventListener) {
+      on = target.addEventListener;
+      off = target.removeEventListener;
+    } else if (target.addListener) {
+      on = target.addListener;
+      off = target.removeListener;
+    } else if (target.on) {
+      on = target.on;
+      off = target.off;
+    }
+
+    if (!on && !off) {
+      throw Error('target does not implement any known event API');
+    }
+
+    if (typeof on !== 'function') {
+      throw TypeError('on method must be a function');
+    }
+
+    if (typeof off !== 'function') {
+      throw TypeError('off method must be a function');
+    }
+
+    this._on = on;
+    this._off = off;
+
+    emitter._observers.push(this);
+  }
+
+  Object.assign(TargetObserver.prototype, {
+    subscribe: function(event, localEvent, reducer){
+      var observer= this;
+      var target= this._target;
+      var emitter= this._emitter;
+      var listeners= this._listeners;
+      var handler= function(){
+        var args= toArray.apply(null, arguments);
+        var eventObj= {
+          data: args,
+          name: localEvent,
+          original: event
+        };
+        if(reducer){
+          var result= reducer.call(target, eventObj);
+          if(result!==false){
+            emitter.emit.apply(emitter, [eventObj.name].concat(args))
+          }
+          return;
+        }
+        emitter.emit.apply(emitter, [localEvent].concat(args));
+      };
+
+
+      if(listeners[event]){
+        throw Error('Event \'' + event + '\' is already listening');
+      }
+
+      this._listenersCount++;
+
+      if(emitter._newListener && emitter._removeListener && !observer._onNewListener){
+
+        this._onNewListener = function (_event) {
+          if (_event === localEvent && listeners[event] === null) {
+            listeners[event] = handler;
+            observer._on.call(target, event, handler);
+          }
+        };
+
+        emitter.on('newListener', this._onNewListener);
+
+        this._onRemoveListener= function(_event){
+          if(_event === localEvent && !emitter.hasListeners(_event) && listeners[event]){
+            listeners[event]= null;
+            observer._off.call(target, event, handler);
+          }
+        };
+
+        listeners[event]= null;
+
+        emitter.on('removeListener', this._onRemoveListener);
+      }else{
+        listeners[event]= handler;
+        observer._on.call(target, event, handler);
+      }
+    },
+
+    unsubscribe: function(event){
+      var observer= this;
+      var listeners= this._listeners;
+      var emitter= this._emitter;
+      var handler;
+      var events;
+      var off= this._off;
+      var target= this._target;
+      var i;
+
+      if(event && typeof event!=='string'){
+        throw TypeError('event must be a string');
+      }
+
+      function clearRefs(){
+        if(observer._onNewListener){
+          emitter.off('newListener', observer._onNewListener);
+          emitter.off('removeListener', observer._onRemoveListener);
+          observer._onNewListener= null;
+          observer._onRemoveListener= null;
+        }
+        var index= findTargetIndex.call(emitter, observer);
+        emitter._observers.splice(index, 1);
+      }
+
+      if(event){
+        handler= listeners[event];
+        if(!handler) return;
+        off.call(target, event, handler);
+        delete listeners[event];
+        if(!--this._listenersCount){
+          clearRefs();
+        }
+      }else{
+        events= ownKeys(listeners);
+        i= events.length;
+        while(i-->0){
+          event= events[i];
+          off.call(target, event, listeners[event]);
+        }
+        this._listeners= {};
+        this._listenersCount= 0;
+        clearRefs();
+      }
+    }
+  });
+
   function resolveOptions(options, schema, reducers, allowUnknown) {
     var computedOptions = Object.assign({}, schema);
 
-    if(!options) return computedOptions;
+    if (!options) return computedOptions;
 
     if (typeof options !== 'object') {
       throw TypeError('options must be an object')
@@ -99,9 +267,10 @@
     var option, value;
     var reducer;
 
-    function reject(reason){
-      throw Error('Invalid "' + option + '" option value' + (reason? '. Reason: '+ reason : ''))
+    function reject(reason) {
+      throw Error('Invalid "' + option + '" option value' + (reason ? '. Reason: ' + reason : ''))
     }
+
     for (var i = 0; i < length; i++) {
       option = keys[i];
       if (!allowUnknown && !hasOwnProperty.call(schema, option)) {
@@ -118,17 +287,25 @@
 
   function constructorReducer(value, reject) {
     if (typeof value !== 'function' || !value.hasOwnProperty('prototype')) {
-      reject('Promise option must be a constructor');
+      reject('value must be a constructor');
     }
     return value;
   }
 
-  function functionReducer(value, reject) {
-    if (typeof value !== 'function') {
-      reject('Promise option must be a function');
-    }
-    return value;
+  function makeTypeReducer(types) {
+    var message= 'value must be type of ' + types.join('|');
+    var conditions= types.map(function(type){
+      return 'a==="'+ type.toLowerCase()+'"';
+    }).join('||');
+
+    return new Function(
+        'm',
+        'return function(v, reject){var a= typeof v;if(!('+ conditions + '))reject(m);return v;}'
+    )(message);
   }
+
+  var functionReducer= makeTypeReducer(['function']);
+  var objectFunctionReducer= makeTypeReducer(['object', 'function']);
 
   function makeCancelablePromise(Promise, executor, options) {
     var isCancelable;
@@ -218,16 +395,15 @@
     return promise;
   }
 
-  function EventEmitter(conf) {
-    this._events = {};
-    this._newListener = false;
-    this._removeListener = false;
-    this.verboseMemoryLeak = false;
-    configure.call(this, conf);
+  function findTargetIndex(observer) {
+    var observers = this._observers;
+    var len = observers.length;
+    for (var i = 0; i < len; i++) {
+      if (observers[i]._target === observer) return i;
+    }
+    return -1;
   }
-  EventEmitter.EventEmitter2 = EventEmitter; // backwards compatibility for exporting EventEmitter property
 
-  //
   // Attention, function return type now is array, always !
   // It has zero elements if no any matches found and one or more
   // elements (leafs) if there are matches
@@ -345,8 +521,8 @@
     //
     // Looks for two consecutive '**', if so, don't add the event at all.
     //
-    for(var i = 0, len = type.length; i+1 < len; i++) {
-      if(type[i] === '**' && type[i+1] === '**') {
+    for (var i = 0, len = type.length; i + 1 < len; i++) {
+      if (type[i] === '**' && type[i + 1] === '**') {
         return;
       }
     }
@@ -366,8 +542,7 @@
 
         if (!tree._listeners) {
           tree._listeners = listener;
-        }
-        else {
+        } else {
           if (typeof tree._listeners === 'function') {
             tree._listeners = [tree._listeners];
           }
@@ -375,9 +550,9 @@
           tree._listeners.push(listener);
 
           if (
-            !tree._listeners.warned &&
-            this._maxListeners > 0 &&
-            tree._listeners.length > this._maxListeners
+              !tree._listeners.warned &&
+              this._maxListeners > 0 &&
+              tree._listeners.length > this._maxListeners
           ) {
             tree._listeners.warned = true;
             logPossibleMemoryLeak.call(this, tree._listeners.length, name);
@@ -389,6 +564,142 @@
     }
     return true;
   }
+
+  function collectTreeEvents(tree, events, root, asArray){
+     var branches= ownKeys(tree);
+     var i= branches.length;
+     var branch, branchName, path;
+     var hasListeners= tree['_listeners'];
+     var isArrayPath;
+
+     while(i-->0){
+         branchName= branches[i];
+
+         branch= tree[branchName];
+
+         if(branchName==='_listeners'){
+             path= root;
+         }else {
+             path = root ? root.concat(branchName) : [branchName];
+         }
+
+         isArrayPath= asArray || typeof branchName==='symbol';
+
+         hasListeners && events.push(isArrayPath? path : path.join(this.delimiter));
+
+         if(typeof branch==='object'){
+             collectTreeEvents.call(this, branch, events, path, isArrayPath);
+         }
+     }
+
+     return events;
+  }
+
+  function recursivelyGarbageCollect(root) {
+    if (!root) {
+      return;
+    }
+    var keys = ownKeys(root);
+    var i= keys.length;
+    var obj, key;
+    while(i-->0){
+      key = keys[i];
+      obj = root[key];
+      if (typeof obj === 'object' && obj.constructor === Object) {
+        if (ownKeys(obj).length) {
+          recursivelyGarbageCollect(obj);
+        } else {
+          delete root[key];
+        }
+      }
+    }
+  }
+
+  function EventEmitter(conf) {
+    this._events = {};
+    this._observers= [];
+    this._newListener = false;
+    this._removeListener = false;
+    this.verboseMemoryLeak = false;
+    configure.call(this, conf);
+  }
+
+  EventEmitter.EventEmitter2 = EventEmitter; // backwards compatibility for exporting EventEmitter property
+
+  EventEmitter.prototype.listenTo= function(target, events, options){
+    if(typeof target!=='object'){
+      throw TypeError('target musts be an object');
+    }
+
+    var emitter= this;
+
+    options = resolveOptions(options, {
+      on: undefined,
+      off: undefined,
+      reducers: undefined
+    }, {
+      on: functionReducer,
+      off: functionReducer,
+      reducers: objectFunctionReducer
+    });
+
+    function listen(events){
+      if(typeof events!=='object'){
+        throw TypeError('events must be an object');
+      }
+
+      var reducers= options.reducers;
+      var index= findTargetIndex.call(emitter, target);
+      var observer;
+
+      if(index===-1){
+        observer= new TargetObserver(emitter, target, options);
+      }else{
+        observer= emitter._observers[index];
+      }
+
+      var keys= ownKeys(events);
+      var len= keys.length;
+      var event;
+      var isSingleReducer= typeof reducers==='function';
+
+      for(var i=0; i<len; i++){
+        event= keys[i];
+        observer.subscribe(
+            event,
+            events[event] || event,
+            isSingleReducer ? reducers : reducers && reducers[event]
+        );
+      }
+    }
+
+    isArray(events)?
+        listen(toObject(events)) :
+        (typeof events==='string'? listen(toObject(events.split(/\s+/))): listen(events));
+
+    return this;
+  };
+
+  EventEmitter.prototype.stopListening = function (target, event) {
+    var observers = this._observers;
+    var i = observers.length;
+    var observer;
+    var matched= false;
+
+    if(target && typeof target!=='object'){
+      throw TypeError('target should be an object');
+    }
+
+    while (i-- > 0) {
+      observer = observers[i];
+      if (!target || observer._target === target) {
+        observer.unsubscribe(event);
+        matched= true;
+      }
+    }
+
+    return matched;
+  };
 
   // By default EventEmitters will print a warning if more than
   // 10 listeners are added to it. This is a useful default which
@@ -462,7 +773,8 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0];
+    var type = arguments[0], ns, wildcard= this.wildcard, kind;
+    var args,l,i,j, containsSymbol;
 
     if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
@@ -470,16 +782,36 @@
       }
     }
 
+    if (wildcard) {
+      kind = typeof type;
+      if (kind === 'string') {
+        ns = type.split(this.delimiter);
+      } else {
+        if(kind==='symbol'){
+          ns= [type];
+        }else{
+          ns = type.slice();
+          l= type.length;
+          if(supportSymbols) {
+            for (i = 0; i < l; i++) {
+              if (typeof type[i] === 'symbol') {
+                containsSymbol = true;
+                break;
+              }
+            }
+          }
+          if(!containsSymbol){
+            type = type.join(this.delimiter);
+          }
+        }
+      }
+    }
+
     var al = arguments.length;
-    var args,l,i,j;
     var handler;
 
     if (this._all && this._all.length) {
       handler = this._all.slice();
-      if (al > 3) {
-        args = new Array(al);
-        for (j = 0; j < al; j++) args[j] = arguments[j];
-      }
 
       for (i = 0, l = handler.length; i < l; i++) {
         this.event = type;
@@ -494,14 +826,13 @@
           handler[i].call(this, type, arguments[1], arguments[2]);
           break;
         default:
-          handler[i].apply(this, args);
+          handler[i].apply(this, arguments);
         }
       }
     }
 
-    if (this.wildcard) {
+    if (wildcard) {
       handler = [];
-      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
     } else {
       handler = this._events[type];
@@ -570,23 +901,44 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0];
+    var type = arguments[0], wildcard= this.wildcard, ns, kind, containsSymbol;
+    var args,l,i,j;
 
     if (type === 'newListener' && !this._newListener) {
         if (!this._events.newListener) { return Promise.resolve([false]); }
     }
 
+    if (wildcard) {
+      kind = typeof type;
+      if (kind === 'string') {
+        ns = type.split(this.delimiter);
+      } else {
+        if(kind==='symbol'){
+          ns= [type];
+        }else{
+          ns = type.slice();
+          l= type.length;
+          if(supportSymbols) {
+            for (i = 0; i < l; i++) {
+              if (typeof type[i] === 'symbol') {
+                containsSymbol = true;
+                break;
+              }
+            }
+          }
+          if(!containsSymbol){
+            type = type.join(this.delimiter);
+          }
+        }
+      }
+    }
+
     var promises= [];
 
     var al = arguments.length;
-    var args,l,i,j;
     var handler;
 
     if (this._all) {
-      if (al > 3) {
-        args = new Array(al);
-        for (j = 1; j < al; j++) args[j] = arguments[j];
-      }
       for (i = 0, l = this._all.length; i < l; i++) {
         this.event = type;
         switch (al) {
@@ -600,14 +952,13 @@
           promises.push(this._all[i].call(this, type, arguments[1], arguments[2]));
           break;
         default:
-          promises.push(this._all[i].apply(this, args));
+          promises.push(this._all[i].apply(this, arguments));
         }
       }
     }
 
-    if (this.wildcard) {
+    if (wildcard) {
       handler = [];
-      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
     } else {
       handler = this._events[type];
@@ -713,8 +1064,9 @@
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".
-    if (this._newListener)
-       this.emit('newListener', type, listener);
+    if (this._newListener) {
+      this.emit('newListener', type, listener);
+    }
 
     if (this.wildcard) {
       growListenerTree.call(this, type, listener);
@@ -724,8 +1076,7 @@
     if (!this._events[type]) {
       // Optimize the case of one listener. Don't need the extra array object.
       this._events[type] = listener;
-    }
-    else {
+    } else {
       if (typeof this._events[type] === 'function') {
         // Change to array.
         this._events[type] = [this._events[type]];
@@ -824,24 +1175,6 @@
       }
     }
 
-    function recursivelyGarbageCollect(root) {
-      if (root === undefined) {
-        return;
-      }
-      var keys = Object.keys(root);
-      for (var i in keys) {
-        var key = keys[i];
-        var obj = root[key];
-        if ((obj instanceof Function) || (typeof obj !== "object") || (obj === null))
-          continue;
-        if (Object.keys(obj).length > 0) {
-          recursivelyGarbageCollect(root[key]);
-        }
-        if (Object.keys(obj).length === 0) {
-          delete root[key];
-        }
-      }
-    }
     recursivelyGarbageCollect(this.listenerTree);
 
     return this;
@@ -872,7 +1205,7 @@
 
   EventEmitter.prototype.removeListener = EventEmitter.prototype.off;
 
-  EventEmitter.prototype.removeAllListeners = function(type) {
+  EventEmitter.prototype.removeAllListeners = function (type) {
     if (type === undefined) {
       !this._events || init.call(this);
       return this;
@@ -882,40 +1215,87 @@
       var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       var leafs = searchListenerTree.call(this, null, ns, this.listenerTree, 0);
 
-      for (var iLeaf=0; iLeaf<leafs.length; iLeaf++) {
+      for (var iLeaf = 0; iLeaf < leafs.length; iLeaf++) {
         var leaf = leafs[iLeaf];
         leaf._listeners = null;
       }
-    }
-    else if (this._events) {
+    } else if (this._events) {
       this._events[type] = null;
     }
     return this;
   };
 
-  EventEmitter.prototype.listeners = function(type) {
-    if (this.wildcard) {
-      var handlers = [];
-      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
-      searchListenerTree.call(this, handlers, ns, this.listenerTree, 0);
-      return handlers;
-    }
+  EventEmitter.prototype.listeners = function (type) {
+    var _events = this._events;
+    var keys, listeners, allListeners;
+    var i;
+    var listenerTree;
 
-    this._events || init.call(this);
+    if (type === undefined) {
+      if (this.wildcard) {
+        throw Error('event name required for wildcard emitter');
+      }
 
-    if (!this._events[type]) this._events[type] = [];
-    if (!isArray(this._events[type])) {
-      this._events[type] = [this._events[type]];
+      if (!_events) {
+        return [];
+      }
+
+      keys = ownKeys(_events);
+      i = keys.length;
+      allListeners = [];
+      while (i-- > 0) {
+        listeners = _events[keys[i]];
+        if (typeof listeners === 'function') {
+          allListeners.push(listeners);
+        } else {
+          allListeners.push.apply(allListeners, listeners);
+        }
+      }
+      return allListeners;
+    } else {
+      if (this.wildcard) {
+        listenerTree= this.listenerTree;
+        if(!listenerTree) return [];
+        var handlers = [];
+        var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+        searchListenerTree.call(this, handlers, ns, listenerTree, 0);
+        return handlers;
+      }
+
+      if (!_events) {
+        return [];
+      }
+
+      listeners = _events[type];
+
+      if (!listeners) {
+        return [];
+      }
+      return typeof listeners === 'function' ? [listeners] : listeners;
     }
-    return this._events[type];
   };
 
-  EventEmitter.prototype.eventNames = function(){
-    return Object.keys(this._events);
+  EventEmitter.prototype.eventNames = function(nsAsArray){
+    var _events= this._events;
+    return this.wildcard? collectTreeEvents.call(this, this.listenerTree, [], null, nsAsArray) : (_events? ownKeys(_events) : []);
   };
 
   EventEmitter.prototype.listenerCount = function(type) {
     return this.listeners(type).length;
+  };
+
+  EventEmitter.prototype.hasListeners = function (type) {
+    if (this.wildcard) {
+      var handlers = [];
+      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+      searchListenerTree.call(this, handlers, ns, this.listenerTree, 0);
+      return handlers.length > 0;
+    }
+
+    var _events = this._events;
+    var _all = this._all;
+
+    return !!(_all && _all.length || _events && (type === undefined ? ownKeys(_events).length : _events[type]));
   };
 
   EventEmitter.prototype.listenersAny = function() {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -11,16 +11,17 @@
     return Object.prototype.toString.call(obj) === "[object Array]";
   };
   var defaultMaxListeners = 10;
-  var supportSymbols= typeof Symbol==='function';
-  var supportReflect= typeof Reflect === 'object';
-  var ownKeys= supportSymbols? (supportReflect && typeof Reflect.ownKeys==='function'? Reflect.ownKeys : function(obj){
+  var nextTickSupported= typeof process=='object' && typeof process.nextTick=='function';
+  var symbolsSupported= typeof Symbol==='function';
+  var reflectSupported= typeof Reflect === 'object';
+  var setImmediateSupported= typeof setImmediate === 'function';
+  var _setImmediate= setImmediateSupported ? setImmediate : setTimeout;
+  var ownKeys= symbolsSupported? (reflectSupported && typeof Reflect.ownKeys==='function'? Reflect.ownKeys : function(obj){
     var arr= Object.getOwnPropertyNames(obj);
     var arr2= Object.getOwnPropertySymbols(obj);
     arr.push.apply(arr, arr2);
     return arr;
   }) : Object.keys;
-
-
 
   function init() {
     this._events = {};
@@ -615,6 +616,67 @@
     }
   }
 
+  function Listener(emitter, event, listener){
+    this.emitter= emitter;
+    this.event= event;
+    this.listener= listener;
+  }
+
+  Listener.prototype.off= function(){
+    this.emitter.off(this.event, this.listener);
+    return this;
+  };
+
+  function setupListener(event, listener, options){
+      if (options === true) {
+        promisify = true;
+      } else if (options === false) {
+        async = true;
+      } else {
+        if (!options || typeof options !== 'object') {
+          throw TypeError('options should be an object or true');
+        }
+        var async = options.async;
+        var promisify = options.promisify;
+        var nextTick = options.nextTick;
+        var objectify = options.objectify;
+      }
+
+      if (async || nextTick || promisify) {
+        var _listener = listener;
+        var _origin = listener._origin || listener;
+
+        if (nextTick && !nextTickSupported) {
+          throw Error('process.nextTick is not supported');
+        }
+
+        if (promisify === undefined) {
+          promisify = listener.constructor.name === 'AsyncFunction';
+        }
+
+        listener = function () {
+          var args = arguments;
+          var context = this;
+          var event = this.event;
+
+          return promisify ? (nextTick ? Promise.resolve() : new Promise(function (resolve) {
+            _setImmediate(resolve);
+          }).then(function () {
+            context.event = event;
+            return _listener.apply(context, args)
+          })) : (nextTick ? process.nextTick : _setImmediate)(function () {
+            context.event = event;
+            _listener.apply(context, args)
+          });
+        };
+
+        listener._async = true;
+        listener._origin = _origin;
+      }
+
+    return [listener, objectify? new Listener(this, event, listener): this];
+  }
+
   function EventEmitter(conf) {
     this._events = {};
     this._observers= [];
@@ -724,28 +786,27 @@
 
   EventEmitter.prototype.event = '';
 
-  EventEmitter.prototype.once = function(event, fn) {
-    return this._once(event, fn, false);
+  EventEmitter.prototype.once = function(event, fn, options) {
+    return this._once(event, fn, false, options);
   };
 
-  EventEmitter.prototype.prependOnceListener = function(event, fn) {
-    return this._once(event, fn, true);
+  EventEmitter.prototype.prependOnceListener = function(event, fn, options) {
+    return this._once(event, fn, true, options);
   };
 
-  EventEmitter.prototype._once = function(event, fn, prepend) {
-    this._many(event, 1, fn, prepend);
-    return this;
+  EventEmitter.prototype._once = function(event, fn, prepend, options) {
+    return this._many(event, 1, fn, prepend, options);
   };
 
-  EventEmitter.prototype.many = function(event, ttl, fn) {
-    return this._many(event, ttl, fn, false);
+  EventEmitter.prototype.many = function(event, ttl, fn, options) {
+    return this._many(event, ttl, fn, false, options);
   };
 
-  EventEmitter.prototype.prependMany = function(event, ttl, fn) {
-    return this._many(event, ttl, fn, true);
+  EventEmitter.prototype.prependMany = function(event, ttl, fn, options) {
+    return this._many(event, ttl, fn, true, options);
   };
 
-  EventEmitter.prototype._many = function(event, ttl, fn, prepend) {
+  EventEmitter.prototype._many = function(event, ttl, fn, prepend, options) {
     var self = this;
 
     if (typeof fn !== 'function') {
@@ -761,9 +822,7 @@
 
     listener._origin = fn;
 
-    this._on(event, listener, prepend);
-
-    return self;
+    return this._on(event, listener, prepend, options);
   };
 
   EventEmitter.prototype.emit = function() {
@@ -792,7 +851,7 @@
         }else{
           ns = type.slice();
           l= type.length;
-          if(supportSymbols) {
+          if(symbolsSupported) {
             for (i = 0; i < l; i++) {
               if (typeof type[i] === 'symbol') {
                 containsSymbol = true;
@@ -918,7 +977,7 @@
         }else{
           ns = type.slice();
           l= type.length;
-          if(supportSymbols) {
+          if(symbolsSupported) {
             for (i = 0; i < l; i++) {
               if (typeof type[i] === 'symbol') {
                 containsSymbol = true;
@@ -1014,12 +1073,12 @@
     return Promise.all(promises);
   };
 
-  EventEmitter.prototype.on = function(type, listener) {
-    return this._on(type, listener, false);
+  EventEmitter.prototype.on = function(type, listener, options) {
+    return this._on(type, listener, false, options);
   };
 
-  EventEmitter.prototype.prependListener = function(type, listener) {
-    return this._on(type, listener, true);
+  EventEmitter.prototype.prependListener = function(type, listener, options) {
+    return this._on(type, listener, true, options);
   };
 
   EventEmitter.prototype.onAny = function(fn) {
@@ -1051,7 +1110,7 @@
     return this;
   };
 
-  EventEmitter.prototype._on = function(type, listener, prepend) {
+  EventEmitter.prototype._on = function(type, listener, prepend, options) {
     if (typeof type === 'function') {
       this._onAny(type, listener);
       return this;
@@ -1061,6 +1120,14 @@
       throw new Error('on only accepts instances of Function');
     }
     this._events || init.call(this);
+
+    var returnValue= this, temp;
+
+    if (options !== undefined) {
+      temp = setupListener.call(this, type, listener, options);
+      listener = temp[0];
+      returnValue = temp[1];
+    }
 
     // To avoid recursion in the case that type == "newListeners"! Before
     // adding it to the listeners, first emit "newListeners".
@@ -1100,7 +1167,7 @@
       }
     }
 
-    return this;
+    return returnValue;
   };
 
   EventEmitter.prototype.off = function(type, listener) {
@@ -1416,7 +1483,7 @@
 
   Object.defineProperties(EventEmitter, {
     defaultMaxListeners: {
-      get: function(){
+      get: function () {
         return prototype._maxListeners;
       },
       set: function (n) {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -146,7 +146,12 @@
     this._on = on;
     this._off = off;
 
-    emitter._observers.push(this);
+    var _observers= emitter._observers;
+    if(_observers){
+      _observers.push(this);
+    }else{
+      emitter._observers= [this];
+    }
   }
 
   Object.assign(TargetObserver.prototype, {
@@ -397,6 +402,9 @@
 
   function findTargetIndex(observer) {
     var observers = this._observers;
+    if(!observers){
+      return -1;
+    }
     var len = observers.length;
     for (var i = 0; i < len; i++) {
       if (observers[i]._target === observer) return i;
@@ -678,7 +686,6 @@
 
   function EventEmitter(conf) {
     this._events = {};
-    this._observers= [];
     this._newListener = false;
     this._removeListener = false;
     this.verboseMemoryLeak = false;
@@ -743,6 +750,11 @@
 
   EventEmitter.prototype.stopListeningTo = function (target, event) {
     var observers = this._observers;
+
+    if(!observers){
+      return false;
+    }
+
     var i = observers.length;
     var observer;
     var matched= false;
@@ -1505,7 +1517,8 @@
           value: defaultMaxListeners,
           writable: true,
           configurable: true
-      }
+      },
+      _observers: {value: null, writable: true, configurable: true}
   });
 
   if (typeof define === 'function' && define.amd) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eventemitter2",
   "version": "6.3.1",
-  "description": "A Node.js event emitter implementation with namespaces, wildcards, TTL, promises and browser support.",
+  "description": "A feature-rich Node.js event emitter implementation with namespaces, wildcards, TTL, async listeners and browser support.",
   "keywords": [
     "event",
     "events",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eventemitter2",
   "version": "6.3.1",
-  "description": "A feature-rich Node.js event emitter implementation with namespaces, wildcards, TTL, async listeners and browser support.",
+  "description": "A feature-rich Node.js event emitter implementation with namespaces, wildcards, TTL, async listeners and browser/worker support.",
   "keywords": [
     "event",
     "events",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
   "repository": "git://github.com/hij1nx/EventEmitter2.git",
   "devDependencies": {
     "benchmark": "^2.1.4",
+    "bluebird": "^3.7.2",
     "coveralls": "^3.0.11",
     "mocha": "^7.1.1",
     "nodeunit": "*",
-    "nyc": "^15.0.0",
-    "bluebird": "^3.7.2"
+    "nyc": "^15.0.0"
   },
   "main": "./lib/eventemitter2.js",
   "scripts": {
@@ -56,10 +56,10 @@
     "definition": "./eventemitter2.d.ts"
   },
   "nyc": {
-    "lines": 83,
-    "functions": 84,
+    "lines": 80,
+    "functions": 80,
     "branches": 75,
-    "statements": 83,
+    "statements": 80,
     "watermarks": {
       "lines": [
         80,

--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -33,8 +33,8 @@ os.cpus().forEach(function(cpu){
   }
 });
 
-console.log('Cpu:' + Object.entries(cpus).map(function([cpu, count]){
-  return [' ', count, ' x ', cpu].join('');
+console.log('CPU:' + Object.entries(cpus).map(function(data){
+  return [' ', data[1], ' x ', data[0]].join('');
 }).join('\n'));
 
 console.log('----------------------------------------------------------------');

--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -1,3 +1,5 @@
+var os= require('os');
+
 
 var Benchmark = require('benchmark');
 var suite = new Benchmark.Suite();
@@ -8,16 +10,42 @@ var emitter = new EventEmitter;
 var EventEmitter2 = require('../../lib/eventemitter2').EventEmitter2;
 var emitter2 = new EventEmitter2;
 
-var EventEmitter3 = require('events').EventEmitter;
+var EventEmitterB = require('events').EventEmitter;
+var emitterB = new EventEmitterB;
+
+var EventEmitter3 = require('eventemitter3').EventEmitter;
 var emitter3 = new EventEmitter3;
 
-suite
+console.log('Platform: ' + [
+  process.platform,
+  process.arch,
+  Math.round((os.totalmem() / (1024 * 1024))) + 'MB'
+].join(', '));
+
+console.log('Node version: ' + process.version);
+var cpus= {};
+os.cpus().forEach(function(cpu){
+  var id= [cpu.model.trim(), ' @ ', cpu.speed, 'MHz'].join('');
+  if(!cpus[id]){
+    cpus[id]= 1;
+  }else{
+    cpus[id]++;
+  }
+});
+
+console.log('Cpu:' + Object.entries(cpus).map(function([cpu, count]){
+  return [' ', count, ' x ', cpu].join('');
+}).join('\n'));
+
+console.log('----------------------------------------------------------------');
+
+    suite
 
   .add('EventEmitterHeatUp', function() {
 
-      emitter3.on('test3', function () { 1==1; });
-      emitter3.emit('test3');
-      emitter3.removeAllListeners('test3');
+      emitterB.on('test3', function () { 1==1; });
+      emitterB.emit('test3');
+      emitterB.removeAllListeners('test3');
 
   })
   .add('EventEmitter', function() {
@@ -41,6 +69,12 @@ suite
     emitter2.emit('test2.foo');
     emitter2.removeAllListeners('test2.foo');
 
+  })
+
+  .add('EventEmitter3', function() {
+    emitter3.on('test2', function () { 1==1; });
+    emitter3.emit('test2');
+    emitter3.removeAllListeners('test2');
   })
 
   .on('cycle', function(event, bench) {

--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "benchmarks",
+  "version": "0.0.0",
+  "dependencies": {
+    "benchmark": "2.1.x",
+    "eventemitter3": "latest"
+  }
+}

--- a/test/simple/addListener.js
+++ b/test/simple/addListener.js
@@ -1,3 +1,4 @@
+var assert= require('assert');
 var simpleEvents = require('nodeunit').testCase;
 var file = '../../lib/eventemitter2';
 var EventEmitter2;
@@ -129,14 +130,14 @@ module.exports = simpleEvents({
     var eventBeingTestedFor, expectedArgument;
     var f = function (event, argument) {
       test.ok(true, 'the event was fired');
-      test.ok(eventBeingTestedFor === event, 'the event is '+event)
+      test.ok(eventBeingTestedFor === event, 'the event is '+event);
       test.ok(expectedArgument === argument, 'the argument is '+argument)
     };
 
     emitter.onAny(f);
     emitter.emit(eventBeingTestedFor = 'test23.ns5.ns5', expectedArgument = 'someData'); //1
     emitter.offAny(f);
-    expectedArgument = undefined
+    expectedArgument = undefined;
     emitter.emit(eventBeingTestedFor = 'test21'); //0
     emitter.onAny(f);
     emitter.onAny(f);
@@ -201,13 +202,13 @@ module.exports = simpleEvents({
 
     var emitter = new EventEmitter2({ verbose: true });
 
-    test.equal(emitter.listenerCount('test1'), 0, 'Before adding listeners listenerCount is 0')
+    test.equal(emitter.listenerCount('test1'), 0, 'Before adding listeners listenerCount is 0');
 
     emitter.on('test1', function () {
       test.ok(true, 'The event was raised');
     });
 
-    test.equal(emitter.listenerCount('test1'), 1, 'After adding a listener listenerCount is 1')
+    test.equal(emitter.listenerCount('test1'), 1, 'After adding a listener listenerCount is 1');
 
     emitter.on('test1', function () {
       test.ok(true, 'The event was raised');
@@ -218,5 +219,140 @@ module.exports = simpleEvents({
     test.expect(3);
     test.done();
 
+  },
+
+  '12. should support wrapping handler to an async listener': function (done) {
+    var ee= new EventEmitter2();
+    var counter= 0;
+    var f= function(x){
+      assert.equal(x, 123);
+      counter++;
+    };
+    ee.on('test', f, false);
+    assert.equal(ee.listenerCount(), 1);
+    ee.emit('test', 123);
+    assert.equal(counter, 0, 'the event was emitted synchronously');
+    setTimeout(function(){
+      assert.equal(counter, 1);
+      ee.off('test', f);
+      assert.equal(ee.listenerCount(), 0);
+      done();
+    }, 10);
+  },
+
+  '13. should support wrapping handler to a promised listener using setImmediate': function (done) {
+    var ee= new EventEmitter2();
+    var counter= 0;
+    var f= function(x){
+      assert.equal(x, 123);
+      counter++;
+      return x + 1;
+    };
+
+    ee.on('test', f, {promisify: true});
+
+    ee.emitAsync('test', 123).then(function(arg){
+      assert.equal(counter, 1);
+      assert.equal(arg, 124);
+      done();
+    }, done);
+
+    assert.equal(counter, 0,'the event was emitted synchronously');
+  },
+
+  '13. should support wrapping handler to an async listener using nextTick': function (done) {
+    var ee= new EventEmitter2();
+    var counter= 0;
+    var f= function(x){
+      assert.equal(x, 123);
+      counter++;
+    };
+    ee.on('test', f, {nextTick: true});
+    assert.equal(ee.listenerCount(), 1);
+    ee.emit('test', 123);
+    assert.equal(counter, 0, 'the event was emitted synchronously');
+    process.nextTick(function(){
+      assert.equal(counter, 1);
+      ee.off('test', f);
+      assert.equal(ee.listenerCount(), 0);
+      done();
+    });
+  },
+
+  '14. should support wrapping once listener to an async listener': function (done) {
+    var ee = new EventEmitter2();
+    var counter = 0;
+    var f = function (x) {
+      assert.equal(x, 123);
+      counter++;
+    };
+    ee.once('test', f, false);
+    assert.equal(ee.listenerCount(), 1);
+    ee.emit('test', 123);
+    assert.equal(counter, 0, 'the event was emitted synchronously');
+    setTimeout(function () {
+      assert.equal(counter, 1);
+      ee.off('test', f);
+      assert.equal(ee.listenerCount(), 0);
+      done();
+    }, 10);
+  },
+
+  '15. should support returning a listener object if the objectify options is set': function () {
+    var ee = new EventEmitter2();
+    var counter = 0;
+    var handler = function (x) {
+      assert.equal(x, 123);
+      counter++;
+    };
+
+    var listener= ee.on('test', handler, {
+      objectify: true
+    });
+
+    assert.equal(typeof listener, 'object');
+    assert.equal(listener.constructor.name, 'Listener');
+    assert.equal(typeof listener.off, 'function');
+    assert.equal(listener.emitter, ee);
+    assert.equal(listener.event, 'test');
+    assert.equal(listener.listener, handler);
+
+    assert.equal(counter, 0);
+
+    ee.emit('test', 123);
+    assert.equal(counter, 1);
+
+    listener.off();
+
+    ee.emit('test', 123);
+    assert.equal(counter, 1);
+  },
+
+  '16. should support returning a listener object using the `once` method if the objectify options is set': function () {
+    var ee = new EventEmitter2();
+    var counter = 0;
+    var handler = function (x) {
+      assert.equal(x, 123);
+      counter++;
+    };
+
+    var listener= ee.once('test', handler, {
+      objectify: true
+    });
+
+    assert.equal(typeof listener, 'object');
+    assert.equal(listener.constructor.name, 'Listener');
+    assert.equal(typeof listener.off, 'function');
+    assert.equal(listener.emitter, ee);
+    assert.equal(listener.event, 'test');
+    assert.equal(listener.listener._origin, handler);
+
+    assert.equal(counter, 0);
+
+    listener.off();
+
+    ee.emit('test', 123);
+
+    assert.equal(counter, 0);
   }
 });

--- a/test/simple/emit.js
+++ b/test/simple/emit.js
@@ -154,5 +154,18 @@ module.exports = simpleEvents({
     test.done();
   },
 
+  '8. Emit event with more than 2 arguments': function (test) {
+    var emitter = new EventEmitter2({ verbose: true });
+
+    emitter.on('test', function(x,y,z){
+      test.equal(x, 1);
+      test.equal(y, 2);
+      test.equal(z, 3);
+    });
+
+    emitter.emit('test', 1, 2, 3);
+    test.expect(3);
+    test.done();
+  }
 });
 

--- a/test/simple/listenTo.js
+++ b/test/simple/listenTo.js
@@ -1,0 +1,242 @@
+var assert = require('assert');
+var EventEmitter = require('events').EventEmitter;
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if (typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+} else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports = {
+    '1. should listen events': function () {
+        var isEmitted= false;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, 'test');
+
+        ee2.on('test', function () {
+            isEmitted = true;
+        });
+
+        ee.emit('test');
+
+        assert.equal(isEmitted, true);
+    },
+
+    '2. should attach listeners to the target object on demand if newListener & removeListener options activated': function () {
+        var isEmitted= false;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2({
+            newListener: true,
+            removeListener: true
+        });
+
+        ee2.listenTo(ee, {
+            'foo': 'bar'
+        });
+
+        assert.equal(ee.listenerCount('foo'), 0);
+
+        ee2.on('bar', function () {
+            isEmitted = true;
+        });
+
+        assert.equal(ee.listenerCount('foo'), 1);
+
+        ee.emit('foo');
+
+
+        assert.equal(isEmitted, true);
+    },
+
+    '3. should handle listener data': function () {
+        var isEmitted= false;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, 'test');
+
+        ee2.on('test', function (a, b, c) {
+            isEmitted = true;
+            assert.equal(a, 1);
+            assert.equal(b, 2);
+            assert.equal(c, 3);
+        });
+
+        assert.equal(ee.listenerCount('test'), 1);
+
+        ee.emit('test', 1, 2, 3);
+
+        assert.equal(isEmitted, true);
+    },
+
+    '4. should support stop listening method': function () {
+        var counter= 0;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, 'test');
+
+        ee2.on('test', function () {
+            counter++;
+        });
+
+        assert.equal(ee.listenerCount('test'), 1);
+
+        ee.emit('test');
+        ee.emit('test');
+
+        ee2.stopListening(ee);
+
+        ee.emit('test');
+
+        assert.equal(counter, 2);
+        assert.equal(ee.listenerCount('test'), 0);
+    },
+
+    '5. should support listening of multiple events': function () {
+        var emitted1= false;
+        var emitted2= false;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, 'test1 test2');
+
+        ee2.on('test1', function () {
+            emitted1= true;
+        });
+
+        ee2.on('test2', function () {
+            emitted2= true;
+        });
+
+        assert.equal(ee.listenerCount('test1'), 1);
+        assert.equal(ee.listenerCount('test2'), 1);
+
+        ee.emit('test1');
+        ee.emit('test2');
+
+        assert.equal(emitted1, true);
+        assert.equal(emitted2, true);
+    },
+
+    '6. should support events mapping': function () {
+        var emitted1= false;
+        var emitted2= false;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, {
+            test1: 'foo',
+            test2: 'bar'
+        });
+
+        ee2.on('foo', function (x) {
+            emitted1= true;
+            assert.equal(x, 1);
+        });
+
+        ee2.on('bar', function (y) {
+            emitted2= true;
+            assert.equal(y, 2);
+        });
+
+        assert.equal(ee.listenerCount('test1'), 1);
+        assert.equal(ee.listenerCount('test2'), 1);
+
+        ee.emit('test1', 1);
+        ee.emit('test2', 2);
+
+        assert.equal(emitted1, true);
+        assert.equal(emitted2, true);
+    },
+
+    '7. should support event reducer': function () {
+        var counter1= 0;
+        var counter2= 0;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, {
+            test1: 'foo',
+            test2: 'bar'
+        }, {
+            reducers: {
+                test1: function(event){
+                    assert.equal(event.name, 'foo');
+                    return event.data[0]!=='ignoreTest';
+                },
+
+                test2: function(event){
+                    assert.equal(event.name, 'bar');
+                    event.data[0]= String(event.data[0]);
+                }
+            }
+        });
+
+        ee2.on('foo', function (x) {
+            counter1++;
+            assert.equal(x, 456);
+        });
+
+        ee2.on('bar', function (y) {
+            counter2++;
+            assert.equal(y, '123');
+        });
+
+        ee.emit('test1', 'ignoreTest');
+        ee.emit('test1', 456);
+        ee.emit('test2', 123);
+        ee.emit('test2', 123);
+
+        assert.equal(counter1, 1);
+        assert.equal(counter2, 2);
+    },
+
+    '8. should support a single reducer for multiple events': function () {
+        var counter1= 0;
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2();
+
+        ee2.listenTo(ee, {
+            test1: 'foo',
+            test2: 'bar'
+        }, {
+            reducers: function(){
+                counter1++;
+            }
+        });
+
+        ee.emit('test1');
+        ee.emit('test2');
+
+        assert.equal(counter1, 2);
+    },
+
+    '9. should detach the listener from the target when the last listener was removed from the emitter': function () {
+        var ee = new EventEmitter();
+        var ee2 = new EventEmitter2({
+            newListener: true,
+            removeListener: true
+        });
+
+        ee2.listenTo(ee, {
+            'foo': 'bar'
+        });
+
+        assert.equal(ee.listenerCount('foo'), 0);
+
+        var handler= function(){};
+
+        ee2.on('bar', handler);
+
+        assert.equal(ee.listenerCount('foo'), 1);
+
+        ee2.off('bar', handler);
+
+        assert.equal(ee.listenerCount('foo'), 0);
+    }
+};

--- a/test/simple/listenTo.js
+++ b/test/simple/listenTo.js
@@ -73,7 +73,7 @@ module.exports = {
         assert.equal(isEmitted, true);
     },
 
-    '4. should support stop listening method': function () {
+    '4. should support stopListeningTo method': function () {
         var counter= 0;
         var ee = new EventEmitter();
         var ee2 = new EventEmitter2();
@@ -89,7 +89,7 @@ module.exports = {
         ee.emit('test');
         ee.emit('test');
 
-        ee2.stopListening(ee);
+        ee2.stopListeningTo(ee);
 
         ee.emit('test');
 

--- a/test/simple/symbol.js
+++ b/test/simple/symbol.js
@@ -1,0 +1,44 @@
+var assert= require('assert');
+
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports= {
+    'should support symbol keys for plain events': function(){
+        var counter= 0;
+        var ee= new EventEmitter2();
+        var event= Symbol('event');
+        var handler= function(){
+            counter++;
+        };
+        ee.on(event, handler);
+        assert.equal(ee.listenerCount(), 1);
+        ee.emit(event);
+        assert.equal(counter, 1);
+        ee.off(event, handler);
+        ee.emit(event);
+        assert.equal(counter, 1);
+        assert.equal(ee.listenerCount(), 0);
+    },
+
+    'should support symbol namespace for wildcard events': function(){
+        var counter= 0;
+        var symbol= Symbol('test');
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+        ee.on(['event', symbol], function(value){
+            counter++;
+            assert.equal(value, 123);
+        });
+        ee.emit(['event', symbol], 123);
+        assert.equal(counter, 1);
+    }
+};

--- a/test/wildcardEvents/eventsNames.js
+++ b/test/wildcardEvents/eventsNames.js
@@ -1,0 +1,53 @@
+var assert = require('assert');
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if (typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+} else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports = {
+    '1. should return wildcard events namespaces': function () {
+        var symbol= Symbol('test');
+
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        var listener;
+
+        ee.on('a.b.c', function(){});
+        ee.on('a.b.d', listener= function(){});
+        ee.on('z.*', function(){});
+        ee.on(['a', 'b', symbol], function(){});
+
+        assert.deepEqual(ee.eventNames(), [ 'z.*', [ 'a', 'b', symbol ], 'a.b.d', 'a.b.c' ]);
+
+        ee.off('a.b.d', listener);
+
+        assert.deepEqual(ee.eventNames(), [ 'z.*', [ 'a', 'b', symbol ], 'a.b.c' ]);
+    },
+
+    '2. should return wildcard events namespaces as array if asArray option was set': function () {
+        var symbol= Symbol('test');
+
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        var listener;
+
+        ee.on('a.b.c', function(){});
+        ee.on('a.b.d', listener= function(){});
+        ee.on('z.*', function(){});
+        ee.on(['a', 'b', symbol], function(){});
+
+        assert.deepEqual(ee.eventNames(true), [ ['z','*'], [ 'a', 'b', symbol ], ['a','b','d'], ['a','b','c']]);
+
+        ee.off('a.b.d', listener);
+
+        assert.deepEqual(ee.eventNames(true), [ ['z','*'], [ 'a', 'b', symbol ], ['a','b','c']]);
+    }
+};

--- a/test/wildcardEvents/normalizeEvent.js
+++ b/test/wildcardEvents/normalizeEvent.js
@@ -1,0 +1,89 @@
+var assert= require('assert');
+
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports= {
+    'should normalize event name when emitting an event': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(typeof this.event==='string');
+            assert.equal(this.event, 'event.test');
+            counter++;
+        });
+
+        ee.emit('event.test');
+        ee.emit(['event', 'test']);
+        assert.equal(counter, 2, 'event not fired');
+    },
+
+    'should normalize event name when emitting an event in async mode': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(typeof this.event==='string');
+            assert.equal(this.event, 'event.test');
+            counter++;
+        });
+
+        return Promise.all([
+            ee.emitAsync('event.test'),
+            ee.emitAsync(['event', 'test'])
+        ]).then(function(){
+            assert.equal(counter, 2, 'event not fired');
+        });
+    },
+
+    'should not convert ns to a string if ns is an array and contains a symbol': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+        var symbol= Symbol('test');
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(Array.isArray(this.event));
+            assert.deepEqual(this.event, ['event', symbol]);
+            counter++;
+        });
+
+        ee.emit(['event', symbol]);
+        assert.equal(counter, 1, 'event not fired');
+    },
+
+    'should not convert ns to a string if ns is an array and contains a symbol while emitting in async mode': function(){
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+        var symbol= Symbol('test');
+        var counter= 0;
+
+        ee.on('**', function(){
+            assert.ok(Array.isArray(this.event));
+            assert.deepEqual(this.event, ['event', symbol]);
+            counter++;
+        });
+
+        return Promise.all([
+            ee.emit(['event', symbol])
+        ]).then(function(){
+            assert.equal(counter, 1, 'event not fired');
+        });
+    }
+};

--- a/test/wildcardEvents/removeAllListeners.js
+++ b/test/wildcardEvents/removeAllListeners.js
@@ -1,0 +1,34 @@
+var assert= require('assert');
+
+var file = '../../lib/eventemitter2';
+var EventEmitter2;
+
+if(typeof require !== 'undefined') {
+    EventEmitter2 = require(file).EventEmitter2;
+}
+else {
+    EventEmitter2 = window.EventEmitter2;
+}
+
+module.exports= {
+    'should remove all wildcard events': function(){
+        var counter=0;
+
+        var ee= new EventEmitter2({
+            wildcard: true
+        });
+
+        ee.on('test.*', function(){
+            counter++;
+        });
+
+        assert.equal(ee.listenerCount('test.*'), 1);
+
+        ee.emit('test.foo');
+
+        assert.equal(counter, 1);
+        ee.removeAllListeners();
+
+        assert.equal(ee.listenerCount('test.*'), 0);
+    }
+};


### PR DESCRIPTION
## [6.4.0] - 2020-05-04

### Added

- Symbol events support for simple and wildcard emitters #201
- `emitter.hasListeners` method #251
- `emitter.listenTo` & `emitter.stopListeningTo` methods for listening to an external event emitter of any kind and propagate its events through itself using optional reducers/filters
- async listeners for invoking handlers using setImmediate|setTimeout|nextTick (see `async`, `promisify` and `nextTicks` options for subscription methods)
- Ability for subscription methods to return a listener object to simplify subscription management (see the `objectify` option)
- micro optimizations for performance reasons

### Fixed

- Event name/reference normalization for the `this.event` property #162
- Bug with data arguments for `Any` listeners #254
- `emitter.eventNames` now supports wildcard emitters #214

```
Platform: win32, x64, 15267MB
Node version: v13.11.0
CPU: 4 x AMD Ryzen 3 2200U with Radeon Vega Mobile Gfx @ 2495MHz
----------------------------------------------------------------
EventEmitterHeatUp x 3,167,076 ops/sec ±3.17% (59 runs sampled)
EventEmitter x 3,190,460 ops/sec ±3.20% (66 runs sampled)
EventEmitter2 x 11,278,456 ops/sec ±4.26% (60 runs sampled)
EventEmitter2 (wild) x 4,620,369 ops/sec ±4.46% (61 runs sampled)
EventEmitter3 x 10,309,717 ops/sec ±3.89% (64 runs sampled)

Fastest is EventEmitter2
```

P.S. Be aware, now we have postversion script to push the tags to the repo and prepublishOnly to run tests before publish.