### PR TITLE
[Release 6.4.1] Optimized wildcard emitter performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 For changes before version 2.2.0, please see the commit history
 
+## [6.4.1] - 2020-05-10
+
+### Fixed
+- increased emitter performance in wildcard mode
+
 ## [6.4.0] - 2020-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ A double wildcard (the string `**`) matches any number of levels (zero or more) 
 emitter.emit('foo');
 emitter.emit('foo.bar');
 emitter.emit('foo.bar.baz');
-emitter.emit(['foo', Symbol(), 'baz');
+emitter.emit(['foo', Symbol(), 'baz']);
 ````
 
 On the other hand, if the single-wildcard event name was passed to the on method, the callback would only observe the second of these events.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Fastest is EventEmitter2
 
 ### What's new
 
-To find out what's new in the latest release see the project [CHANGELOG](https://github.com/EventEmitter2/EventEmitter2/blob/master/CHANGELOG.md)
+To find out what's new see the project [CHANGELOG](https://github.com/EventEmitter2/EventEmitter2/blob/master/CHANGELOG.md)
 
 ### Differences (Non-breaking, compatible with existing EventEmitter)
 
@@ -101,7 +101,7 @@ In these cases this.event remains as is (symbol and array).
  - Fire an event N times and then remove it, an extension of the `once` concept.
 
 ```javascript
-server.many('foo', 4, function() {
+emitter.many('foo', 4, function() {
   console.log('hello');
 });
 ```
@@ -109,7 +109,7 @@ server.many('foo', 4, function() {
  - Pass in a namespaced event as an array rather than a delimited string.
 
 ```javascript
-server.many(['foo', 'bar', 'bazz'], 4, function() {
+emitter.many(['foo', 'bar', 'bazz'], 4, function() {
   console.log('hello');
 });
 ```
@@ -251,12 +251,12 @@ On the other hand, if the single-wildcard event name was passed to the on method
 Adds a listener to the end of the listeners array for the specified event.
 
 ```javascript
-server.on('data', function(value1, value2, value3, ...) {
+emitter.on('data', function(value1, value2, value3, ...) {
   console.log('The event was raised!');
 });
 ```
 ```javascript
-server.on('data', function(value) {
+emitter.on('data', function(value) {
   console.log('The event was raised!');
 });
 ```
@@ -353,7 +353,7 @@ all listeners were resolved!
 Adds a listener to the beginning of the listeners array for the specified event.
 
 ```javascript
-server.prependListener('data', function(value1, value2, value3, ...) {
+emitter.prependListener('data', function(value1, value2, value3, ...) {
   console.log('The event was raised!');
 });
 ```
@@ -367,7 +367,7 @@ server.prependListener('data', function(value1, value2, value3, ...) {
 Adds a listener that will be fired when any event is emitted. The event name is passed as the first argument to the callback.
 
 ```javascript
-server.onAny(function(event, value) {
+emitter.onAny(function(event, value) {
   console.log('All events trigger this.');
 });
 ```
@@ -377,7 +377,7 @@ server.onAny(function(event, value) {
 Adds a listener that will be fired when any event is emitted. The event name is passed as the first argument to the callback. The listener is added to the beginning of the listeners array
 
 ```javascript
-server.prependAny(function(event, value) {
+emitter.prependAny(function(event, value) {
   console.log('All events trigger this.');
 });
 ```
@@ -387,7 +387,7 @@ server.prependAny(function(event, value) {
 Removes the listener that will be fired when any event is emitted.
 
 ```javascript
-server.offAny(function(value) {
+emitter.offAny(function(value) {
   console.log('The event was raised!');
 });
 ```
@@ -398,7 +398,7 @@ Adds a **one time** listener for the event. The listener is invoked
 only the first time the event is fired, after which it is removed.
 
 ```javascript
-server.once('get', function (value) {
+emitter.once('get', function (value) {
   console.log('Ah, we have our first value!');
 });
 ```
@@ -414,7 +414,7 @@ only the first time the event is fired, after which it is removed.
 The listener is added to the beginning of the listeners array
 
 ```javascript
-server.prependOnceListener('get', function (value) {
+emitter.prependOnceListener('get', function (value) {
   console.log('Ah, we have our first value!');
 });
 ```
@@ -430,7 +430,7 @@ removed. The listener is invoked only the first **n times** the event is
 fired, after which it is removed.
 
 ```javascript
-server.many('get', 4, function (value) {
+emitter.many('get', 4, function (value) {
   console.log('This event will be listened to exactly four times.');
 });
 ```
@@ -447,7 +447,7 @@ fired, after which it is removed.
 The listener is added to the beginning of the listeners array.
 
 ```javascript
-server.many('get', 4, function (value) {
+emitter.many('get', 4, function (value) {
   console.log('This event will be listened to exactly four times.');
 });
 ```
@@ -466,9 +466,9 @@ Remove a listener from the listener array for the specified event.
 var callback = function(value) {
   console.log('someone connected!');
 };
-server.on('get', callback);
+emitter.on('get', callback);
 // ...
-server.removeListener('get', callback);
+emitter.removeListener('get', callback);
 ```
 
 
@@ -496,10 +496,10 @@ Returns an array of listeners for the specified event. This array can be
 manipulated, e.g. to remove listeners.
 
 ```javascript
-server.on('get', function(value) {
+emitter.on('get', function(value) {
   console.log('someone connected!');
 });
-console.log(server.listeners('get')); // [ [Function] ]
+console.log(emitter.listeners('get')); // [ [Function] ]
 ```
 
 ### emitter.listenersAny()
@@ -508,10 +508,10 @@ Returns an array of listeners that are listening for any event that is
 specified. This array can be manipulated, e.g. to remove listeners.
 
 ```javascript
-server.onAny(function(value) {
+emitter.onAny(function(value) {
   console.log('someone connected!');
 });
-console.log(server.listenersAny()[0]); // [ [Function] ]
+console.log(emitter.listenersAny()[0]); // [ [Function] ]
 ```
 
 ### emitter.emit(event | eventNS, [arg1], [arg2], [...])

--- a/README.md
+++ b/README.md
@@ -606,15 +606,18 @@ emitter.emit('event', new Error('custom error')); // reject the promise
 ````
 ### emitter.eventNames(nsAsArray)
 
-Returns an array listing the events for which the emitter has registered listeners. The values in the array will be strings.
+Returns an array listing the events for which the emitter has registered listeners.
 ```javascript
 var emitter= new EventEmitter2();
 emitter.on('foo', () => {});
 emitter.on('bar', () => {});
+emitter.on(Symbol('test'), () => {});
+emitter.on(['foo', Symbol('test2')], () => {});
 
 console.log(emitter.eventNames());
-// Prints: [ 'foo', 'bar' ]
+// Prints: [ 'bar', 'foo', [ 'foo', Symbol(test2) ], [ 'foo', Symbol(test2) ] ]
 ```
+**Note**: Listeners order not guaranteed
 ### listenTo(targetEmitter, events: event | eventNS, options?)
 
 ### listenTo(targetEmitter, events: (event | eventNS)[], options?)

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ emitter.emit('foo.bar', 1, 2); // 'foo.bar' 1 2
 emitter.emit(['foo', 'bar'], 3, 4); // 'foo.bar' 3 4
 
 emitter.emit(Symbol(), 5, 6); // Symbol() 5 6
-emitter.emit(['foo', Symbol(), 7, 8]); // ['foo', Symbol()] 7 8
+emitter.emit(['foo', Symbol()], 7, 8); // ['foo', Symbol()] 7 8
 ```
 **Note**: Generally this.event is normalized to a string ('event', 'event.test'),
 except the cases when event is a symbol or namespace contains a symbol. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/EventEmitter2/EventEmitter2.svg?branch=master)](https://travis-ci.com/EventEmitter2/EventEmitter2)
+[![Build Status](https://travis-ci.org/EventEmitter2/EventEmitter2.svg?branch=master)](https://travis-ci.org/EventEmitter2/EventEmitter2)
 [![Coverage Status](https://coveralls.io/repos/github/EventEmitter2/EventEmitter2/badge.svg?branch=master)](https://coveralls.io/github/EventEmitter2/EventEmitter2?branch=master)
 [![NPM version](https://badge.fury.io/js/eventemitter2.svg)](http://badge.fury.io/js/eventemitter2)
 [![Dependency Status](https://img.shields.io/david/asyncly/eventemitter2.svg)](https://david-dm.org/asyncly/eventemitter2)

--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ Platform: win32, x64, 15267MB
 Node version: v13.11.0
 CPU: 4 x AMD Ryzen 3 2200U with Radeon Vega Mobile Gfx @ 2495MHz
 ----------------------------------------------------------------
-EventEmitterHeatUp x 3,167,076 ops/sec ±3.17% (59 runs sampled)
-EventEmitter x 3,190,460 ops/sec ±3.20% (66 runs sampled)
-EventEmitter2 x 11,278,456 ops/sec ±4.26% (60 runs sampled)
-EventEmitter2 (wild) x 4,620,369 ops/sec ±4.46% (61 runs sampled)
-EventEmitter3 x 10,309,717 ops/sec ±3.89% (64 runs sampled)
+EventEmitterHeatUp x 2,897,056 ops/sec ±3.86% (67 runs sampled)
+EventEmitter x 3,232,934 ops/sec ±3.50% (65 runs sampled)
+EventEmitter2 x 12,261,042 ops/sec ±4.72% (59 runs sampled)
+EventEmitter2 (wild) x 242,751 ops/sec ±5.15% (68 runs sampled)
+EventEmitter2 (wild) using plain events x 358,916 ops/sec ±2.58% (78 runs sampled)
+EventEmitter2 (wild) emitting ns x 1,837,323 ops/sec ±3.50% (72 runs sampled)
+EventEmitter2 (wild) emitting a plain event x 2,743,707 ops/sec ±4.08% (65 runs sampled)
+EventEmitter3 x 10,380,258 ops/sec ±3.93% (67 runs sampled)
 
 Fastest is EventEmitter2
 ```
@@ -675,23 +678,23 @@ setTimeout(function(){
 ````
 An example of using a wildcard emitter in a browser:
 ````javascript
-    const ee= new EventEmitter2({
-        wildcard: true
-    });
+const ee= new EventEmitter2({
+   wildcard: true
+});
 
-    ee.listenTo(document.querySelector('#test'), {
-        'click': 'div.click',
-        'mouseup': 'div.mouseup',
-        'mousedown': 'div.mousedown'
-    });
+ee.listenTo(document.querySelector('#test'), {
+   'click': 'div.click',
+   'mouseup': 'div.mouseup',
+   'mousedown': 'div.mousedown'
+});
 
-    ee.on('div.*', function(evt){
-        console.log('listenTo: '+ evt.type);
-    });
+ee.on('div.*', function(evt){
+    console.log('listenTo: '+ evt.type);
+});
 
-    setTimeout(function(){
-      ee.stopListeningTo(document.querySelector('#test'));
-    }, 30000);
+setTimeout(function(){
+    ee.stopListeningTo(document.querySelector('#test'));
+}, 30000);
 ````
 
 ### stopListeningTo(target?: Object, event: event | eventNS): Boolean

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -418,7 +418,7 @@
   //
   function searchListenerTree(handlers, type, tree, i, typeLength) {
     if (!tree) {
-      return [];
+      return null;
     }
 
     if (i === 0) {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -416,12 +416,17 @@
   // It has zero elements if no any matches found and one or more
   // elements (leafs) if there are matches
   //
-  function searchListenerTree(handlers, type, tree, i) {
+  function searchListenerTree(handlers, type, tree, i, typeLength) {
     if (!tree) {
       return [];
     }
-    var listeners=[], leaf, len, branch, xTree, xxTree, isolatedBranch, endReached,
-        typeLength = type.length, currentType = type[i], nextType = type[i+1];
+    var listeners= null, branch, xTree, xxTree, isolatedBranch, endReached, currentType = type[i],
+        nextType = type[i + 1], branches, n, _listeners;
+
+    if (!typeLength) {
+      typeLength = type.length;
+    }
+
     if (i === typeLength && tree._listeners) {
       //
       // If at the end of the event(s) list and the tree has listeners
@@ -431,91 +436,117 @@
         handlers && handlers.push(tree._listeners);
         return [tree];
       } else {
-        for (leaf = 0, len = tree._listeners.length; leaf < len; leaf++) {
-          handlers && handlers.push(tree._listeners[leaf]);
-        }
+        handlers && handlers.push.apply(handlers, tree._listeners);
         return [tree];
       }
     }
 
-    if ((currentType === '*' || currentType === '**') || tree[currentType]) {
+    if (currentType === '*') {
       //
       // If the event emitted is '*' at this part
       // or there is a concrete match at this patch
       //
-      if (currentType === '*') {
-        for (branch in tree) {
-          if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
-            listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i+1));
-          }
-        }
-        return listeners;
-      } else if(currentType === '**') {
-        endReached = (i+1 === typeLength || (i+2 === typeLength && nextType === '*'));
-        if(endReached && tree._listeners) {
-          // The next element has a _listeners, add it to the handlers.
-          listeners = listeners.concat(searchListenerTree(handlers, type, tree, typeLength));
-        }
-
-        for (branch in tree) {
-          if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
-            if(branch === '*' || branch === '**') {
-              if(tree[branch]._listeners && !endReached) {
-                listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], typeLength));
-              }
-              listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i));
-            } else if(branch === nextType) {
-              listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i+2));
-            } else {
-              // No match on this one, shift into the tree but not in the type array.
-              listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i));
+      branches= ownKeys(tree);
+      n= branches.length;
+      while(n-->0){
+        branch= branches[n];
+        if (branch !== '_listeners') {
+          _listeners = searchListenerTree(handlers, type, tree[branch], i + 1, typeLength);
+          if(_listeners){
+            if(listeners){
+              listeners.push.apply(listeners, _listeners);
+            }else{
+              listeners = _listeners;
             }
           }
         }
-        return listeners;
+      }
+      return listeners;
+    } else if (currentType === '**') {
+      endReached = (i + 1 === typeLength || (i + 2 === typeLength && nextType === '*'));
+      if (endReached && tree._listeners) {
+        // The next element has a _listeners, add it to the handlers.
+        listeners = searchListenerTree(handlers, type, tree, typeLength, typeLength);
       }
 
-      listeners = listeners.concat(searchListenerTree(handlers, type, tree[currentType], i+1));
+      branches= ownKeys(tree);
+      n= branches.length;
+      while(n-->0){
+        branch= branches[n];
+        if (branch !== '_listeners') {
+          if (branch === '*' || branch === '**') {
+            if (tree[branch]._listeners && !endReached) {
+              _listeners = searchListenerTree(handlers, type, tree[branch], typeLength, typeLength);
+              if(_listeners){
+                if(listeners){
+                  listeners.push.apply(listeners, _listeners);
+                }else{
+                  listeners = _listeners;
+                }
+              }
+            }
+            _listeners = searchListenerTree(handlers, type, tree[branch], i, typeLength);
+          } else if (branch === nextType) {
+            _listeners = searchListenerTree(handlers, type, tree[branch], i + 2, typeLength);
+          } else {
+            // No match on this one, shift into the tree but not in the type array.
+            _listeners = searchListenerTree(handlers, type, tree[branch], i, typeLength);
+          }
+          if(_listeners){
+            if(listeners){
+              listeners.push.apply(listeners, _listeners);
+            }else{
+              listeners = _listeners;
+            }
+          }
+        }
+      }
+      return listeners;
+    }else if (tree[currentType]) {
+      listeners= searchListenerTree(handlers, type, tree[currentType], i + 1, typeLength);
     }
 
-    xTree = tree['*'];
+      xTree = tree['*'];
     if (xTree) {
       //
       // If the listener tree will allow any match for this part,
       // then recursively explore all branches of the tree
       //
-      searchListenerTree(handlers, type, xTree, i+1);
+      searchListenerTree(handlers, type, xTree, i + 1, typeLength);
     }
 
     xxTree = tree['**'];
-    if(xxTree) {
-      if(i < typeLength) {
-        if(xxTree._listeners) {
+    if (xxTree) {
+      if (i < typeLength) {
+        if (xxTree._listeners) {
           // If we have a listener on a '**', it will catch all, so add its handler.
-          searchListenerTree(handlers, type, xxTree, typeLength);
+          searchListenerTree(handlers, type, xxTree, typeLength, typeLength);
         }
 
         // Build arrays of matching next branches and others.
-        for(branch in xxTree) {
-          if(branch !== '_listeners' && xxTree.hasOwnProperty(branch)) {
-            if(branch === nextType) {
+        branches= ownKeys(xxTree);
+        n= branches.length;
+        while(n-->0){
+          branch= branches[n];
+          if (branch !== '_listeners') {
+            if (branch === nextType) {
               // We know the next element will match, so jump twice.
-              searchListenerTree(handlers, type, xxTree[branch], i+2);
-            } else if(branch === currentType) {
+              searchListenerTree(handlers, type, xxTree[branch], i + 2, typeLength);
+            } else if (branch === currentType) {
               // Current node matches, move into the tree.
-              searchListenerTree(handlers, type, xxTree[branch], i+1);
+              searchListenerTree(handlers, type, xxTree[branch], i + 1, typeLength);
             } else {
               isolatedBranch = {};
               isolatedBranch[branch] = xxTree[branch];
-              searchListenerTree(handlers, type, { '**': isolatedBranch }, i+1);
+              searchListenerTree(handlers, type, {'**': isolatedBranch}, i + 1, typeLength);
             }
           }
         }
-      } else if(xxTree._listeners) {
+      } else if (xxTree._listeners) {
         // We have reached the end and still on a '**'
-        searchListenerTree(handlers, type, xxTree, typeLength);
-      } else if(xxTree['*'] && xxTree['*']._listeners) {
-        searchListenerTree(handlers, type, xxTree['*'], typeLength);
+        searchListenerTree(handlers, type, xxTree, typeLength, typeLength);
+      } else if (xxTree['*'] && xxTree['*']._listeners) {
+        searchListenerTree(handlers, type, xxTree['*'], typeLength, typeLength);
       }
     }
 
@@ -844,6 +875,7 @@
 
     var type = arguments[0], ns, wildcard= this.wildcard, kind;
     var args,l,i,j, containsSymbol;
+    var delimiter= this.delimiter;
 
     if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
@@ -854,24 +886,30 @@
     if (wildcard) {
       kind = typeof type;
       if (kind === 'string') {
-        ns = type.split(this.delimiter);
-      } else {
-        if(kind==='symbol'){
-          ns= [type];
-        }else{
-          ns = type.slice();
-          l= type.length;
-          if(symbolsSupported) {
-            for (i = 0; i < l; i++) {
-              if (typeof type[i] === 'symbol') {
-                containsSymbol = true;
-                break;
-              }
+        l = 0;
+        j = 0;
+        if ((i = type.indexOf(delimiter)) !== -1) {
+          ns = new Array(5);
+          do {
+            ns[l++] = type.slice(j, i);
+            j = i + 1;
+          } while ((i = type.indexOf(delimiter, j + 1)) !== -1);
+
+          ns[l++] = type.slice(j);
+        }
+      } else if (kind !== 'symbol') {
+        ns = type.slice();
+        l = type.length;
+        if (symbolsSupported) {
+          for (i = 0; i < l; i++) {
+            if (typeof type[i] === 'symbol') {
+              containsSymbol = true;
+              break;
             }
           }
-          if(!containsSymbol){
-            type = type.join(this.delimiter);
-          }
+        }
+        if (!containsSymbol) {
+          type = type.join(delimiter);
         }
       }
     }
@@ -902,7 +940,7 @@
 
     if (wildcard) {
       handler = [];
-      searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
+      searchListenerTree.call(this, handler, ns || [type], this.listenerTree, 0, l);
     } else {
       handler = this._events[type];
       if (typeof handler === 'function') {
@@ -1190,8 +1228,8 @@
     if(this.wildcard) {
       var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
       leafs = searchListenerTree.call(this, null, ns, this.listenerTree, 0);
-    }
-    else {
+      if(!leafs) return this;
+    } else {
       // does not use listeners(), so no side effect of creating _events[type]
       if (!this._events[type]) return this;
       handlers = this._events[type];
@@ -1289,9 +1327,20 @@
     }
 
     if (this.wildcard) {
-      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
-      var leafs = searchListenerTree.call(this, null, ns, this.listenerTree, 0);
+      var ns, i, l, j, delimiter= this.delimiter;
+      l = 0;
+      j = 0;
+      if ((i = type.indexOf(delimiter)) !== -1) {
+        ns = new Array(5);
+        do {
+          ns[l++] = type.slice(j, i);
+          j = i + 1;
+        } while ((i = type.indexOf(delimiter, j + 1)) !== -1);
 
+        ns[l++] = type.slice(j);
+      }
+      var leafs = searchListenerTree.call(this, null, ns || [type], this.listenerTree, 0, l);
+      if(!leafs) return this;
       for (var iLeaf = 0; iLeaf < leafs.length; iLeaf++) {
         var leaf = leafs[iLeaf];
         leaf._listeners = null;

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -448,7 +448,7 @@
     }
 
     var listeners= null, branch, xTree, xxTree, isolatedBranch, endReached, currentType = type[i],
-        nextType = type[i + 1], branches, n, _listeners;
+        nextType = type[i + 1], branches, _listeners;
 
     if (i === typeLength && tree._listeners) {
       //

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -420,12 +420,35 @@
     if (!tree) {
       return [];
     }
+
+    if (i === 0) {
+      var kind = typeof type;
+      if (kind === 'string') {
+        var ns, n, l = 0, j = 0, delimiter = this.delimiter, dl = delimiter.length;
+        if ((n = type.indexOf(delimiter)) !== -1) {
+          ns = new Array(5);
+          do {
+            ns[l++] = type.slice(j, n);
+            j = n + dl;
+          } while ((n = type.indexOf(delimiter, j)) !== -1);
+
+          ns[l++] = type.slice(j);
+          type = ns;
+          typeLength = l;
+        } else {
+          type = [type];
+          typeLength = 1;
+        }
+      } else if (kind === 'object') {
+        typeLength = type.length;
+      } else {
+        type = [type];
+        typeLength = 1;
+      }
+    }
+
     var listeners= null, branch, xTree, xxTree, isolatedBranch, endReached, currentType = type[i],
         nextType = type[i + 1], branches, n, _listeners;
-
-    if (!typeLength) {
-      typeLength = type.length;
-    }
 
     if (i === typeLength && tree._listeners) {
       //
@@ -889,9 +912,8 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0], ns, wildcard= this.wildcard, kind;
+    var type = arguments[0], ns, wildcard= this.wildcard;
     var args,l,i,j, containsSymbol;
-    var delimiter, dl;
 
     if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
@@ -900,34 +922,21 @@
     }
 
     if (wildcard) {
-      delimiter= this.delimiter;
-      dl= delimiter.length;
-      kind = typeof type;
-      if (kind === 'string') {
-        l = 0;
-        j = 0;
-        if ((i = type.indexOf(delimiter)) !== -1) {
-          ns = new Array(5);
-          do {
-            ns[l++] = type.slice(j, i);
-            j = i + dl;
-          } while ((i = type.indexOf(delimiter, j)) !== -1);
-
-          ns[l++] = type.slice(j);
-        }
-      } else if (kind !== 'symbol') {
-        ns = type.slice();
-        l = type.length;
-        if (symbolsSupported) {
-          for (i = 0; i < l; i++) {
-            if (typeof type[i] === 'symbol') {
-              containsSymbol = true;
-              break;
+      ns= type;
+      if(type!=='newListener' && type!=='removeListener'){
+        if (typeof type === 'object') {
+          l = type.length;
+          if (symbolsSupported) {
+            for (i = 0; i < l; i++) {
+              if (typeof type[i] === 'symbol') {
+                containsSymbol = true;
+                break;
+              }
             }
           }
-        }
-        if (!containsSymbol) {
-          type = type.join(delimiter);
+          if (!containsSymbol) {
+            type = type.join(this.delimiter);
+          }
         }
       }
     }
@@ -958,7 +967,7 @@
 
     if (wildcard) {
       handler = [];
-      searchListenerTree.call(this, handler, ns || [type], this.listenerTree, 0, l);
+      searchListenerTree.call(this, handler, ns, this.listenerTree, 0, l);
     } else {
       handler = this._events[type];
       if (typeof handler === 'function') {
@@ -1026,7 +1035,7 @@
 
     this._events || init.call(this);
 
-    var type = arguments[0], wildcard= this.wildcard, ns, kind, containsSymbol;
+    var type = arguments[0], wildcard= this.wildcard, ns, containsSymbol;
     var args,l,i,j;
 
     if (type === 'newListener' && !this._newListener) {
@@ -1034,16 +1043,11 @@
     }
 
     if (wildcard) {
-      kind = typeof type;
-      if (kind === 'string') {
-        ns = type.split(this.delimiter);
-      } else {
-        if(kind==='symbol'){
-          ns= [type];
-        }else{
-          ns = type.slice();
-          l= type.length;
-          if(symbolsSupported) {
+      ns= type;
+      if(type!=='newListener' && type!=='removeListener'){
+        if (typeof type === 'object') {
+          l = type.length;
+          if (symbolsSupported) {
             for (i = 0; i < l; i++) {
               if (typeof type[i] === 'symbol') {
                 containsSymbol = true;
@@ -1051,7 +1055,7 @@
               }
             }
           }
-          if(!containsSymbol){
+          if (!containsSymbol) {
             type = type.join(this.delimiter);
           }
         }
@@ -1345,22 +1349,10 @@
     }
 
     if (this.wildcard) {
-      var ns, i, l, j, delimiter= this.delimiter, dl= delimiter.length;
-      l = 0;
-      j = 0;
-      if ((i = type.indexOf(delimiter)) !== -1) {
-        ns = new Array(5);
-        do {
-          ns[l++] = type.slice(j, i);
-          j = i + dl;
-        } while ((i = type.indexOf(delimiter, j)) !== -1);
-
-        ns[l++] = type.slice(j);
-      }
-      var leafs = searchListenerTree.call(this, null, ns || [type], this.listenerTree, 0, l);
-      if(!leafs) return this;
-      for (var iLeaf = 0; iLeaf < leafs.length; iLeaf++) {
-        var leaf = leafs[iLeaf];
+      var leafs = searchListenerTree.call(this, null, type, this.listenerTree, 0), leaf, i;
+      if (!leafs) return this;
+      for (i = 0; i < leafs.length; i++) {
+        leaf = leafs[i];
         leaf._listeners = null;
       }
       this.listenerTree && recursivelyGarbageCollect(this.listenerTree);

--- a/test/perf/benchmark.js
+++ b/test/perf/benchmark.js
@@ -10,6 +10,17 @@ var emitter = new EventEmitter;
 var EventEmitter2 = require('../../lib/eventemitter2').EventEmitter2;
 var emitter2 = new EventEmitter2;
 
+var wildcardEmitter = new EventEmitter2({
+  wildcard: true
+});
+
+var wildcardEmitter2 = new EventEmitter2({
+  wildcard: true
+});
+
+wildcardEmitter2.on('test2.foo', function () { 1==1; });
+wildcardEmitter2.on('test2', function () { 1==1; });
+
 var EventEmitterB = require('events').EventEmitter;
 var emitterB = new EventEmitterB;
 
@@ -65,10 +76,24 @@ console.log('----------------------------------------------------------------');
 
   .add('EventEmitter2 (wild)', function() {
 
-    emitter2.on('test2.foo', function () { 1==1; });
-    emitter2.emit('test2.foo');
-    emitter2.removeAllListeners('test2.foo');
+    wildcardEmitter.on('test2.foo', function () { 1==1; });
+    wildcardEmitter.emit('test2.foo');
+    wildcardEmitter.removeAllListeners('test2.foo');
 
+  })
+
+  .add('EventEmitter2 (wild) using plain events', function() {
+    wildcardEmitter.on('test2', function () { 1==1; });
+    wildcardEmitter.emit('test2');
+    wildcardEmitter.removeAllListeners('test2');
+  })
+
+  .add('EventEmitter2 (wild) emitting ns', function() {
+    wildcardEmitter2.emit('test2.foo');
+  })
+
+  .add('EventEmitter2 (wild) emitting a plain event', function() {
+    wildcardEmitter2.emit('test2');
   })
 
   .add('EventEmitter3', function() {

--- a/test/simple/emit.js
+++ b/test/simple/emit.js
@@ -144,7 +144,6 @@ module.exports = simpleEvents({
 
     emitter.on('test7', functionA);
     emitter.on('wildcard.*', functionA);
-
     test.ok(emitter.emit('test7'), 'emit should return true after calling a listener');
     test.ok(emitter.emit('wildcard.7'), 'emit should return true after calling a wildcard listener');
     test.ok(!emitter.emit('other7'), 'emit should return false when no listener was called');

--- a/test/wildcardEvents/removeAllListeners.js
+++ b/test/wildcardEvents/removeAllListeners.js
@@ -21,7 +21,7 @@ module.exports= {
         ee.on('test.*', function(){
             counter++;
         });
-        debugger;
+
         assert.equal(ee.listenerCount('test.*'), 1);
 
         ee.emit('test.foo');

--- a/test/wildcardEvents/removeAllListeners.js
+++ b/test/wildcardEvents/removeAllListeners.js
@@ -21,7 +21,7 @@ module.exports= {
         ee.on('test.*', function(){
             counter++;
         });
-
+        debugger;
         assert.equal(ee.listenerCount('test.*'), 1);
 
         ee.emit('test.foo');


### PR DESCRIPTION
A bit of simple optimizations for a wildcard emitter, especially for cases when we emitting a simple one level event through wildcard emitter (become almost 4 times faster than before)
before:

> EventEmitter2 x 12,089,852 ops/sec ±4.00% (62 runs sampled)
> **EventEmitter2 (wild) x 167,847 ops/sec ±4.90% (63 runs sampled)**
> EventEmitter2 (wild) using plain events x 190,736 ops/sec ±3.08% (62 runs sampled)
> EventEmitter2 (wild) emitting ns x 676,378 ops/sec ±4.07% (67 runs sampled)
> EventEmitter2 (wild) emitting a plain event x 764,142 ops/sec ±3.87% (71 runs sampled)
> EventEmitter3 x 10,223,124 ops/sec ±3.51% (70 runs sampled)

after:

> Platform: win32, x64, 15267MB
> Node version: v13.11.0
> CPU: 4 x AMD Ryzen 3 2200U with Radeon Vega Mobile Gfx @ 2495MHz
> ----------------------------------------------------------------
> EventEmitterHeatUp x 3,299,321 ops/sec ±3.10% (69 runs sampled)
> EventEmitter x 3,185,748 ops/sec ±3.11% (72 runs sampled)
> EventEmitter2 x 12,538,440 ops/sec ±3.76% (65 runs sampled)
> **EventEmitter2 (wild) x 217,123 ops/sec ±9.80% (66 runs sampled)**
> **EventEmitter2 (wild) using plain events x 278,079 ops/sec ±3.80% (55 runs sampled)**
> **EventEmitter2 (wild) emitting ns x 1,717,662 ops/sec ±4.17% (70 runs sampled)
> EventEmitter2 (wild) emitting a plain event x 2,898,598 ops/sec ±3.48% (72 runs sampled)**
> EventEmitter3 x 10,730,209 ops/sec ±4.59% (63 runs sampled)
> 
> Fastest is EventEmitter2
