### PR TITLE
[Release 6.4.2] removed eval usage to avoid Content Security Policy issue (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 For changes before version 2.2.0, please see the commit history
 
+## [6.4.2] - 2020-05-28
+
+### Fixed
+- removed eval usage to avoid Content Security Policy issue (#259) @DigitalBrainJS
+
 ## [6.4.1] - 2020-05-10
 
 ### Fixed
-- increased emitter performance in wildcard mode
+- increased emitter performance in wildcard mode @DigitalBrainJS
 
 ## [6.4.0] - 2020-05-04
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/EventEmitter2/EventEmitter2.svg?branch=master)](https://travis-ci.org/EventEmitter2/EventEmitter2)
-[![Coverage Status](https://coveralls.io/repos/github/EventEmitter2/EventEmitter2/badge.svg?branch=master)](https://coveralls.io/github/EventEmitter2/EventEmitter2?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/EventEmitter2/EventEmitter2/badge.svg?branch=v6.4.1)](https://coveralls.io/github/EventEmitter2/EventEmitter2?branch=v6.4.1)
 [![NPM version](https://badge.fury.io/js/eventemitter2.svg)](http://badge.fury.io/js/eventemitter2)
 [![Dependency Status](https://img.shields.io/david/asyncly/eventemitter2.svg)](https://david-dm.org/asyncly/eventemitter2)
 [![npm](https://img.shields.io/npm/dm/eventemitter2.svg?maxAge=2592000)]()

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -338,7 +338,7 @@
     var isCancelable;
     var callbacks;
     var timer= 0;
-    var subscribeClosed;
+    var subscriptionClosed;
 
     var promise = new Promise(function (resolve, reject, onCancel) {
       options= resolveOptions(options, {
@@ -383,7 +383,7 @@
           _reject(reason || Error('canceled'));
         }];
         executor(_resolve, _reject, function (cb) {
-          if (subscribeClosed) {
+          if (subscriptionClosed) {
             throw Error('Unable to subscribe on cancel event asynchronously')
           }
           if (typeof cb !== 'function') {
@@ -391,7 +391,7 @@
           }
           callbacks.push(cb);
         });
-        subscribeClosed= true;
+        subscriptionClosed= true;
       }
 
       if (options.timeout > 0) {

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -299,17 +299,39 @@
 
   function makeTypeReducer(types) {
     var message= 'value must be type of ' + types.join('|');
-    var conditions= types.map(function(type){
-      return 'a==="'+ type.toLowerCase()+'"';
-    }).join('||');
+    var len= types.length;
+    var firstType= types[0];
+    var secondType= types[1];
 
-    return new Function(
-        'm',
-        'return function(v, reject){var a= typeof v;if(!('+ conditions + '))reject(m);return v;}'
-    )(message);
+    if (len === 1) {
+      return function (v, reject) {
+        if (typeof v === firstType) {
+          return v;
+        }
+        reject(message);
+      }
+    }
+
+    if (len === 2) {
+      return function (v, reject) {
+        var kind= typeof v;
+        if (kind === firstType || kind === secondType) return v;
+        reject(message);
+      }
+    }
+
+    return function (v, reject) {
+      var kind = typeof v;
+      var i = len;
+      while (i-- > 0) {
+        if (kind === types[i]) return v;
+      }
+      reject(message);
+    }
   }
 
   var functionReducer= makeTypeReducer(['function']);
+
   var objectFunctionReducer= makeTypeReducer(['object', 'function']);
 
   function makeCancelablePromise(Promise, executor, options) {


### PR DESCRIPTION
Reworked `makeTypeReducer` internal function (#259);