### PR TITLE
set ETIMEDOUT code on timeout exception

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -397,6 +397,7 @@
       if (options.timeout > 0) {
         timer= setTimeout(function(){
           var reason= Error('timeout');
+          reason.code = 'ETIMEDOUT'
           timer= 0;
           promise.cancel(reason);
           reject(reason);


### PR DESCRIPTION
Small change that makes the timeout exception behave similarly to other libraries (e.g Q) by providing an error code on the exception.