### PR TITLE
fix removeAllListeners not emitting a removeListener event

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -1376,10 +1376,20 @@
       if (!leafs) return this;
       for (i = 0; i < leafs.length; i++) {
         leaf = leafs[i];
+        if (this._removeListener){
+          for (var i = 0; i < leaf._listeners.length; i++) {
+            this.emit("removeListener", type, leaf._listeners[i]);
+          }
+        }
         leaf._listeners = null;
       }
       this.listenerTree && recursivelyGarbageCollect(this.listenerTree);
     } else if (this._events) {
+      if (this._removeListener){
+        for (var i = 0; i < this._events[type].length; i++) {
+          this.emit("removeListener", type, this._events[type][i]);
+        }
+      }
       this._events[type] = null;
     }
     return this;


### PR DESCRIPTION
Added the removeListener event when removeAllListeners to be consistent with node buildin eventemitter