### PR TITLE
feat(emit): added feature to interrupt emit

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -892,6 +892,23 @@
   };
 
   EventEmitter.prototype.event = '';
+  EventEmitter.prototype._signal = false;
+  EventEmitter.macro = Object.assign({}, {
+    SIGINT: symbolsSupported ? Symbol.for('signal.sigint') : 0xeac6;
+  });
+  
+  EventEmitter.prototype._sendSignal = function(signal) {
+    this._signal = signal;
+    return this;
+  };
+  
+  EventEmitter.prototype._clearSignal = function() {
+    return this._sendSignal(false);
+  };
+  
+  EventEmitter.prototype.stopImmediatePropagation = function() {
+    return this._sendSignal(EventEmitter.macro.SIGINT);
+  };
 
   EventEmitter.prototype.once = function(event, fn, options) {
     return this._once(event, fn, false, options);
@@ -941,6 +958,15 @@
 
     var type = arguments[0], ns, wildcard= this.wildcard;
     var args,l,i,j, containsSymbol;
+    
+    function interrupted(result = undefined) {
+      var macro = EventEmitter.macro.SIGINT;
+      if (this._signal === macro) {
+        this._clearSignal()
+        return true
+      };
+      return result === macro;
+    };
 
     if (type === 'newListener' && !this._newListener) {
       if (!this._events.newListener) {
@@ -978,17 +1004,18 @@
         this.event = type;
         switch (al) {
         case 1:
-          handler[i].call(this, type);
+          if (interrupted.call(this, handler[i].call(this, type))) return true;
           break;
         case 2:
-          handler[i].call(this, type, arguments[1]);
+          if (interrupted.call(this, handler[i].call(this, type, arguments[1]))) return true;
           break;
         case 3:
-          handler[i].call(this, type, arguments[1], arguments[2]);
+          if (interrupted.call(this, handler[i].call(this, type, arguments[1], arguments[2]))) return true;
           break;
         default:
-          handler[i].apply(this, arguments);
+          if (interrupted.call(this, handler[i].apply(this, arguments))) return true;
         }
+        if (interrupted.call(this)) return true;
       }
     }
 
@@ -1001,18 +1028,18 @@
         this.event = type;
         switch (al) {
         case 1:
-          handler.call(this);
+          if (interrupted.call(this, handler.call(this))) return true;
           break;
         case 2:
-          handler.call(this, arguments[1]);
+          if (interrupted.call(this, handler.call(this, arguments[1]))) return true;
           break;
         case 3:
-          handler.call(this, arguments[1], arguments[2]);
+          if (interrupted.call(this, handler.call(this, arguments[1], arguments[2]))) return true;
           break;
         default:
           args = new Array(al - 1);
           for (j = 1; j < al; j++) args[j - 1] = arguments[j];
-          handler.apply(this, args);
+          if (interrupted.call(this, handler.apply(this, args))) return true;
         }
         return true;
       } else if (handler) {
@@ -1031,17 +1058,18 @@
         this.event = type;
         switch (al) {
         case 1:
-          handler[i].call(this);
+          if (interrupted.call(this, handler[i].call(this))) return true;
           break;
         case 2:
-          handler[i].call(this, arguments[1]);
+          if (interrupted.call(this, handler[i].call(this, arguments[1]))) return true;
           break;
         case 3:
-          handler[i].call(this, arguments[1], arguments[2]);
+          if (interrupted.call(this, handler[i].call(this, arguments[1], arguments[2]))) return true;
           break;
         default:
-          handler[i].apply(this, args);
+          if (interrupted.call(this, handler[i].apply(this, args))) return true;
         }
+        if (interrupted.call(this)) return true;
       }
       return true;
     } else if (!this.ignoreErrors && !this._all && type === 'error') {


### PR DESCRIPTION
Added feature to interrupt the currently running synchronous emit process.

* replaces existing and outdated pull-request #127
* returning `EventEmitter.macro.SIGINT` constant from the handler prevents other listeners of the same event from being called
* calling `this.stopImmediatePropagation()` inside the handler prevents other listeners of the same event from being called