### PR TITLE
Use Promise.allSettled instead of Promise.all to finish execution of all listeners

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -1171,7 +1171,12 @@
       }
     }
 
-    return Promise.all(promises);
+    // wait all promises to finish before throwing
+    return Promise.allSettled(promises).then(results => {
+      const firstRejected = results.find(result => result.status === 'rejected');
+      if (firstRejected) throw firstRejected.reason; // throws first rejected to keep compatibility with Promise.all
+      return results.map(result => result.value);
+    });
   };
 
   EventEmitter.prototype.on = function(type, listener, options) {

--- a/test/simple/emitAsync.js
+++ b/test/simple/emitAsync.js
@@ -108,4 +108,54 @@ module.exports = simpleEvents({
       test.done();
     });
   },
+  '5. Finish execution of all listeners regardless if any failed': function (test) {
+    var emitter = new EventEmitter2({ verbose: true });
+    var counter = 0;
+
+    emitter.on('foo', function() {
+      return Promise.reject('First Failed')
+    });
+    emitter.on('foo', function() {
+      return new Promise(function(resolve, reject){
+        setTimeout(function(){
+          reject('Second Failed');
+        },50);
+      });
+    });
+    emitter.on('foo', function() {
+      return new Promise(function(resolve){
+        setTimeout(function(){
+          resolve(counter++);
+        },50);
+      });
+    });
+    emitter.on('foo', function() {
+      return new Promise(function(resolve){
+        setTimeout(function(){
+          resolve(counter++);
+        },50);
+      });
+    });
+    emitter.on('foo', function() {
+      return new Promise(function(resolve){
+        setTimeout(function(){
+          resolve(counter++);
+        },50);
+      });
+    });
+    emitter.on('foo', function() {
+      return new Promise(function(resolve){
+        setTimeout(function(){
+          resolve(counter++);
+        },100);
+      });
+    });
+
+    emitter.emitAsync('foo')
+      .catch(function(firstError){
+        test.equal(firstError, 'First Failed')
+        test.equal(counter, 4) // but all were executed
+        test.done();
+      });
+  },
 });


### PR DESCRIPTION
closes #283

On an application with multiple listeners to the same event when using [Promise.all](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all) It rejects immediately upon any of the input promises rejecting or non-promises throwing an error, and will reject with this first rejection message / error.

While [Promise.allSettled](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled) is typically used when you have multiple asynchronous tasks that are not dependent on one another to complete successfully, or you'd always like to know the result of each promise, which is the use case of having multiple listeners for the same event.