### PR TITLE
Replace function constructor with expression

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -1623,7 +1623,7 @@
   }
   else {
     // global for any kind of environment.
-    var _global= new Function('','return this')();
+    var _global= (function(){return this})();
     _global.EventEmitter2 = EventEmitter;
   }
 }();


### PR DESCRIPTION
To eliminate CSP 'unsafe-eval' violation (https://www.w3.org/TR/CSP/latest/#allowed-script-sources).
This change would eliminate a warning that is issued when submitting a browser add-on (which utilizes EventEmitter2) for publication.