### PR TITLE
Add default export to type definitions. fixes #281

### DIFF
--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -148,3 +148,5 @@ export declare class EventEmitter2 {
     static once(emitter: EventEmitter2, event: event | eventNS, options?: OnceOptions): CancelablePromise<any[]>;
     static defaultMaxListeners: number;
 }
+
+export default EventEmitter2;


### PR DESCRIPTION
@RangerMauve turns out this was only a problem on typescript.
Because it didn't have a default export, we had to do

```ts
import { EventEmitter2 } from 'eventemitter2';
```

With the default export declaration, we can just do

```ts
import EventEmitter from 'eventemitter2';
```

This is a breaking change **only** for typescript users.