### PR TITLE
Improve typescript definitions by using generics

### DIFF
--- a/eventemitter2.d.ts
+++ b/eventemitter2.d.ts
@@ -1,156 +1,197 @@
-export type event = (symbol|string);
-export type eventNS = string|event[];
-
 export interface ConstructorOptions {
-    /**
-     * @default false
-     * @description set this to `true` to use wildcards.
-     */
-    wildcard?: boolean,
-    /**
-     * @default '.'
-     * @description the delimiter used to segment namespaces.
-     */
-    delimiter?: string,
-    /**
-     * @default false
-     * @description set this to `true` if you want to emit the newListener events.
-     */
-    newListener?: boolean,
-    /**
-     * @default false
-     * @description set this to `true` if you want to emit the removeListener events.
-     */
-    removeListener?: boolean,
-    /**
-     * @default 10
-     * @description the maximum amount of listeners that can be assigned to an event.
-     */
-    maxListeners?: number
-    /**
-     * @default false
-     * @description show event name in memory leak message when more than maximum amount of listeners is assigned, default false
-     */
-    verboseMemoryLeak?: boolean
-    /**
-     * @default false
-     * @description disable throwing uncaughtException if an error event is emitted and it has no listeners
-     */
-    ignoreErrors?: boolean
-}
-export interface ListenerFn {
-    (...values: any[]): void;
-}
-export interface EventAndListener {
-    (event: string | string[], ...values: any[]): void;
+  /**
+   * @default false
+   * @description set this to `true` to use wildcards.
+   */
+  wildcard?: boolean,
+  /**
+   * @default '.'
+   * @description the delimiter used to segment namespaces.
+   */
+  delimiter?: string,
+  /**
+   * @default false
+   * @description set this to `true` if you want to emit the newListener events.
+   */
+  newListener?: boolean,
+  /**
+   * @default false
+   * @description set this to `true` if you want to emit the removeListener events.
+   */
+  removeListener?: boolean,
+  /**
+   * @default 10
+   * @description the maximum amount of listeners that can be assigned to an event.
+   */
+  maxListeners?: number
+  /**
+   * @default false
+   * @description show event name in memory leak message when more than maximum amount of listeners is assigned, default false
+   */
+  verboseMemoryLeak?: boolean
+  /**
+   * @default false
+   * @description disable throwing uncaughtException if an error event is emitted and it has no listeners
+   */
+  ignoreErrors?: boolean
 }
 
-export interface WaitForFilter { (...values: any[]): boolean }
+export type event = (symbol | string);
+export type eventNS = string | event[];
 
-export interface WaitForOptions {
-    /**
-     * @default 0
-     */
-    timeout: number,
-    /**
-     * @default null
-     */
-    filter: WaitForFilter,
-    /**
-     * @default false
-     */
-    handleError: boolean,
-    /**
-     * @default Promise
-     */
-    Promise: Function,
-    /**
-     * @default false
-     */
-    overload: boolean
+export interface EventMap {
+  [key: event]: (...args: any) => void
 }
 
-export interface CancelablePromise<T> extends Promise<T>{
-    cancel(reason: string): undefined
+export type ListenerFn<EventName extends keyof Events = event, Events extends EventMap = EventMap> = Events[EventName]
+
+export interface EventAndListener<EventName extends keyof Events = event, Events extends EventMap = EventMap> {
+  (event: EventName, ...values: ListenerFunctionParameters<EventName, Events>): void;
+}
+
+export interface WaitForFilter<EventName extends keyof Events = event, Events extends EventMap = EventMap> {
+  (...values: ListenerFunctionParameters<EventName, Events>): boolean
+}
+
+export interface WaitForOptions<EventName extends keyof Events = event, Events extends EventMap = EventMap> {
+  /**
+   * @default 0
+   */
+  timeout: number,
+  /**
+   * @default null
+   */
+  filter: WaitForFilter<EventName, Events>,
+  /**
+   * @default false
+   */
+  handleError: boolean,
+  /**
+   * @default Promise
+   */
+  Promise: Function,
+  /**
+   * @default false
+   */
+  overload: boolean
+}
+
+export interface CancelablePromise<T> extends Promise<T> {
+  cancel(reason: string): undefined
 }
 
 export interface OnceOptions {
-    /**
-     * @default 0
-     */
-    timeout: number,
-    /**
-     * @default Promise
-     */
-    Promise: Function,
-    /**
-     * @default false
-     */
-    overload: boolean
+  /**
+   * @default 0
+   */
+  timeout: number,
+  /**
+   * @default Promise
+   */
+  Promise: Function,
+  /**
+   * @default false
+   */
+  overload: boolean
 }
 
-export interface ListenToOptions {
-    on?: { (event: event | eventNS, handler: ListenerFn): void },
-    off?: { (event: event | eventNS, handler: ListenerFn): void },
-    reducers: Function | Object
+export interface ListenToOptions<EventName extends keyof Events = event, Events extends EventMap = EventMap> {
+  on?: { (event: EventName | eventNS, handler: ListenerFn<EventName, Events>): void },
+  off?: { (event: EventName | eventNS, handler: ListenerFn<EventName, Events>): void },
+  reducers: Function | Object
 }
 
-export interface GeneralEventEmitter{
-    addEventListener(event: event, handler: ListenerFn): this,
-    removeEventListener(event: event, handler: ListenerFn): this,
-    addListener?(event: event, handler: ListenerFn): this,
-    removeListener?(event: event, handler: ListenerFn): this,
-    on?(event: event, handler: ListenerFn): this,
-    off?(event: event, handler: ListenerFn): this
+export interface GeneralEventEmitter<EventName extends keyof Events = event, Events extends EventMap = EventMap> {
+  addEventListener(event: EventName, handler: ListenerFn<EventName, Events>): this,
+
+  removeEventListener(event: EventName, handler: ListenerFn<EventName, Events>): this,
+
+  addListener?(event: EventName, handler: ListenerFn<EventName, Events>): this,
+
+  removeListener?(event: EventName, handler: ListenerFn<EventName, Events>): this,
+
+  on?(event: EventName, handler: ListenerFn<EventName, Events>): this,
+
+  off?(event: EventName, handler: ListenerFn<EventName, Events>): this
 }
 
 export interface OnOptions {
-    async?: boolean,
-    promisify?: boolean,
-    nextTick?: boolean,
-    objectify?: boolean
+  async?: boolean,
+  promisify?: boolean,
+  nextTick?: boolean,
+  objectify?: boolean
 }
 
-export interface Listener {
-    emitter: EventEmitter2;
-    event: event|eventNS;
-    listener: ListenerFn;
-    off(): this;
+export interface Listener<EventName extends keyof Events = event, Events extends EventMap = EventMap> {
+  emitter: EventEmitter2<Events>;
+  event: EventName | eventNS;
+  listener: ListenerFn<EventName, Events>;
+
+  off(): this;
 }
 
-export declare class EventEmitter2 {
-    constructor(options?: ConstructorOptions)
-    emit(event: event | eventNS, ...values: any[]): boolean;
-    emitAsync(event: event | eventNS, ...values: any[]): Promise<any[]>;
-    addListener(event: event | eventNS, listener: ListenerFn): this|Listener;
-    on(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
-    prependListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
-    once(event: event | eventNS, listener: ListenerFn, options?: true|OnOptions): this|Listener;
-    prependOnceListener(event: event | eventNS, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
-    many(event: event | eventNS, timesToListen: number, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
-    prependMany(event: event | eventNS, timesToListen: number, listener: ListenerFn, options?: boolean|OnOptions): this|Listener;
-    onAny(listener: EventAndListener): this;
-    prependAny(listener: EventAndListener): this;
-    offAny(listener: ListenerFn): this;
-    removeListener(event: event | eventNS, listener: ListenerFn): this;
-    off(event: event | eventNS, listener: ListenerFn): this;
-    removeAllListeners(event?: event | eventNS): this;
-    setMaxListeners(n: number): void;
-    getMaxListeners(): number;
-    eventNames(nsAsArray?: boolean): (event|eventNS)[];
-    listenerCount(event?: event | eventNS): number
-    listeners(event?: event | eventNS): ListenerFn[]
-    listenersAny(): ListenerFn[]
-    waitFor(event: event | eventNS, timeout?: number): CancelablePromise<any[]>
-    waitFor(event: event | eventNS, filter?: WaitForFilter): CancelablePromise<any[]>
-    waitFor(event: event | eventNS, options?: WaitForOptions): CancelablePromise<any[]>
-    listenTo(target: GeneralEventEmitter, events: event | eventNS, options?: ListenToOptions): this;
-    listenTo(target: GeneralEventEmitter, events: event[], options?: ListenToOptions): this;
-    listenTo(target: GeneralEventEmitter, events: Object, options?: ListenToOptions): this;
-    stopListeningTo(target?: GeneralEventEmitter, event?: event | eventNS): Boolean;
-    hasListeners(event?: String): Boolean
-    static once(emitter: EventEmitter2, event: event | eventNS, options?: OnceOptions): CancelablePromise<any[]>;
-    static defaultMaxListeners: number;
+export type ListenerFunctionParameters<EventName extends keyof Events = event, Events extends EventMap = EventMap> = Parameters<ListenerFn<EventName, Events>>
+
+export declare class EventEmitter2<Events extends EventMap = EventMap> {
+  constructor(options?: ConstructorOptions)
+
+  emit<EventName extends keyof Events>(event: EventName | eventNS, ...values: ListenerFunctionParameters<EventName, Events>): boolean;
+
+  emitAsync<EventName extends keyof Events>(event: EventName | eventNS, ...values: ListenerFunctionParameters<EventName, Events>): Promise<ReturnType<ListenerFn<EventName, Events>>[]>;
+
+  addListener<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>): this | Listener<EventName, Events>;
+
+  on<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>, options?: boolean | OnOptions): this | Listener<EventName, Events>;
+
+  prependListener<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>, options?: boolean | OnOptions): this | Listener<EventName, Events>;
+
+  once<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>, options?: true | OnOptions): this | Listener<EventName, Events>;
+
+  prependOnceListener<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>, options?: boolean | OnOptions): this | Listener<EventName, Events>;
+
+  many<EventName extends keyof Events>(event: EventName | eventNS, timesToListen: number, listener: ListenerFn<EventName, Events>, options?: boolean | OnOptions): this | Listener<EventName, Events>;
+
+  prependMany<EventName extends keyof Events>(event: EventName | eventNS, timesToListen: number, listener: ListenerFn<EventName, Events>, options?: boolean | OnOptions): this | Listener<EventName, Events>;
+
+  onAny<EventName extends keyof Events>(listener: EventAndListener<EventName, Events>): this;
+
+  prependAny<EventName extends keyof Events>(listener: EventAndListener<EventName, Events>): this;
+
+  offAny<EventName extends keyof Events>(listener: ListenerFn<EventName, Events>): this;
+
+  removeListener<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>): this;
+
+  off<EventName extends keyof Events>(event: EventName | eventNS, listener: ListenerFn<EventName, Events>): this;
+
+  removeAllListeners<EventName extends keyof Events>(event?: EventName | eventNS): this;
+
+  setMaxListeners(numberOfListeners: number): void;
+
+  getMaxListeners(): number;
+
+  eventNames<EventName extends keyof Events>(nsAsArray?: boolean): (EventName | eventNS)[];
+
+  listenerCount<EventName extends keyof Events>(event?: EventName | eventNS): number
+
+  listeners<EventName extends keyof Events>(event?: EventName | eventNS): ListenerFn<EventName, Events>[]
+
+  listenersAny<EventName extends keyof Events>(): ListenerFn<EventName, Events>[]
+
+  waitFor<EventName extends keyof Events>(event: EventName | eventNS, timeout?: number): CancelablePromise<ListenerFunctionParameters<EventName, Events>>
+  waitFor<EventName extends keyof Events>(event: EventName | eventNS, filter?: WaitForFilter<EventName, Events>): CancelablePromise<ListenerFunctionParameters<EventName, Events>>
+  waitFor<EventName extends keyof Events>(event: EventName | eventNS, options?: WaitForOptions<EventName, Events>): CancelablePromise<ListenerFunctionParameters<EventName, Events>>
+
+  listenTo<EventName extends keyof Events>(target: GeneralEventEmitter<EventName, Events>, events: EventName | eventNS, options?: ListenToOptions<EventName, Events>): this;
+  listenTo<EventName extends keyof Events>(target: GeneralEventEmitter<EventName, Events>, events: EventName[], options?: ListenToOptions<EventName, Events>): this;
+  listenTo<EventName extends keyof Events>(target: GeneralEventEmitter<EventName, Events>, events: Object, options?: ListenToOptions<EventName, Events>): this;
+
+  stopListeningTo<EventName extends keyof Events>(target?: GeneralEventEmitter<EventName, Events>, event?: EventName | eventNS): Boolean;
+
+  hasListeners<EventName extends keyof Events>(event?: EventName): Boolean
+
+  static once<EventName extends keyof Events = event, Events extends EventMap = EventMap>(emitter: EventEmitter2<Events>, event: EventName | eventNS, options?: OnceOptions): CancelablePromise<ListenerFunctionParameters<EventName, Events>>;
+
+  static defaultMaxListeners: number
 }
 
-export default EventEmitter2;
+export default EventEmitter2


### PR DESCRIPTION
Inspired by https://github.com/andywer/typed-emitter I replaced the usage of `any` with generics to make the typescript definitions more type safe. I tried to keep the compatibility with the old types. 

You now can define a map of constrains between an event name and the value types which will be enforced by typescript.