### PR TITLE
logPossibleMemoryLeak throws an error when event name is a Symbol

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -57,7 +57,7 @@
         'Use emitter.setMaxListeners() to increase limit.';
 
     if(this.verboseMemoryLeak){
-      errorMsg += ' Event name: ' + eventName + '.';
+      errorMsg += ' Event name: ' + String(eventName) + '.';
     }
 
     if(typeof process !== 'undefined' && process.emitWarning){

--- a/test/simple/symbol.js
+++ b/test/simple/symbol.js
@@ -40,5 +40,24 @@ module.exports= {
         });
         ee.emit(['event', symbol], 123);
         assert.equal(counter, 1);
-    }
+    },
+
+    'should log possible memory leak when max listeners is exceeded for a symbol event': async function () {
+        const warnings= [];
+        process.on('warning', (e) => {
+          warnings.push(e);
+        });
+        var symbol= Symbol('event');
+        var ee= new EventEmitter2({
+          maxListeners: 1,
+          verboseMemoryLeak: true,
+        });
+        ee.on(symbol, () => {});
+        ee.on(symbol, () => {});
+        await new Promise(res => {
+          setTimeout(res, 0);
+        });
+        assert.ok(warnings.length > 0);
+        assert.ok(warnings.find((e) => e.name === 'MaxListenersExceededWarning'));
+      }
 };


### PR DESCRIPTION
fix for https://github.com/EventEmitter2/EventEmitter2/issues/296