### PR TITLE
Adjust recent heading levels in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 For changes before version 2.2.0, please see the commit history
 
-# [6.4.5] - 2021-10-03
+## [6.4.5] - 2021-10-03
 
 ### Fixed
 - invoking a wildcard listener when there is also a matching exact listener (#278) @DigitalBrainJS
 
-# [6.4.4] - 2021-02-23
+## [6.4.4] - 2021-02-23
 
 ### Added 
 - `ETIMEDOUT` code property to timeout errors @HalleyAssist
@@ -19,7 +19,7 @@ For changes before version 2.2.0, please see the commit history
 ### Fixed
 - prepending listeners to wildcard emitters @Ilrilan
 
-# [6.4.3] - 2020-06-18
+## [6.4.3] - 2020-06-18
 
 ### Fixed
 - ignoring the `objectify` option in wildcard mode (#265) @DigitalBrainJS


### PR DESCRIPTION
The last three releases used an H1 heading instead of H2.