### PR TITLE
Make universal global object reference

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -1628,13 +1628,13 @@
 
     // Global for any kind of JS environment
     var _global =
-      typeof globalThis == 'object' && isGlobal(globalThis) && globalThis ||
-      typeof window == 'object' && isGlobal(window) && window ||
-      typeof global == 'object' && isGlobal(global) && global ||
-      typeof self == 'object' && isGlobal(self) && self ||
+      typeof globalThis === 'object' && isGlobal(globalThis) && globalThis ||
+      typeof window === 'object' && isGlobal(window) && window ||
+      typeof global === 'object' && isGlobal(global) && global ||
+      typeof self === 'object' && isGlobal(self) && self ||
       (function () { return this; })() ||
       this ||
-      new Function('','return this')();
+      new Function('', 'return this')();
 
     _global.EventEmitter2 = EventEmitter;
   }

--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -1622,8 +1622,20 @@
     module.exports = EventEmitter;
   }
   else {
-    // global for any kind of environment.
-    var _global= new Function('','return this')();
+    function isGlobal(obj) {
+      return Boolean(obj) && obj.Math === Math;
+    }
+
+    // Global for any kind of JS environment
+    var _global =
+      typeof globalThis == 'object' && isGlobal(globalThis) && globalThis ||
+      typeof window == 'object' && isGlobal(window) && window ||
+      typeof global == 'object' && isGlobal(global) && global ||
+      typeof self == 'object' && isGlobal(self) && self ||
+      (function () { return this; })() ||
+      this ||
+      new Function('','return this')();
+
     _global.EventEmitter2 = EventEmitter;
   }
 }();


### PR DESCRIPTION
Fixes for https://github.com/EventEmitter2/EventEmitter2/issues/303.

The code has been adapted from [core-js](https://github.com/zloirock/core-js/blob/6f484834c14eed50dfe4009481743284d16eca5f/packages/core-js/internals/global.js#L6) with some style modifications.