### PR TITLE
Fix bug in removeAllListeners()

### DIFF
--- a/lib/eventemitter2.js
+++ b/lib/eventemitter2.js
@@ -1384,11 +1384,11 @@
       if (!leafs) return this;
       for (i = 0; i < leafs.length; i++) {
         leaf = leafs[i];
-        leaf._listeners = null;
+        delete leaf._listeners;
       }
       this.listenerTree && recursivelyGarbageCollect(this.listenerTree);
     } else if (this._events) {
-      this._events[type] = null;
+      delete this._events[type];
     }
     return this;
   };


### PR DESCRIPTION
I was trying to use eventNames() with removeAllListeners() and noticed that it didn't actually remove the event name. Fortunately, removeListener()/off() works as expected and I was able to use that instead, but I figured I should fix the bug, now that I have found it.